### PR TITLE
fix(site): 0818 audit — link rewriting, package counts, AuthKit copy

### DIFF
--- a/content/docs/authkit/account-lockout.mdx
+++ b/content/docs/authkit/account-lockout.mdx
@@ -1,6 +1,7 @@
 ---
 title: Account Lockout
 description: Progressive per-email lockout, complementary to IP rate-limiting.
+icon: LockKeyhole
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/agora-integration.mdx
+++ b/content/docs/authkit/agora-integration.mdx
@@ -1,6 +1,7 @@
 ---
 title: Agora integration
 description: How AuthKit wires into the Agora ecosystem — diagnostics events, request context, Authz, resilience, and durable GDPR workflows.
+icon: Blocks
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/agora-integration.mdx
+++ b/content/docs/authkit/agora-integration.mdx
@@ -13,7 +13,7 @@ library is absent.
 
 ## Diagnostics events (`agora:authkit:*`)
 
-AuthKit republishes **every audit event** onto the Agora [diagnostics bus](/docs/diagnostics)
+AuthKit republishes **every audit event type** onto the Agora [diagnostics bus](/docs/diagnostics)
 as `agora:authkit:<AuditEventType>` — for example:
 
 ```text
@@ -29,6 +29,15 @@ agora:authkit:organization.invitation_accepted
 The audit sink does the republish automatically. It is **fire-and-forget**: it never touches
 the request path, and `emit()` is guarded (`hasSubscribers`) so it is a true no-op when
 nothing is subscribed.
+
+<Callout type="warn">
+  The **payload is redacted** on this bridge. Only `{ type, accountId, actorId, clientId }`
+  cross it — `email`, `ip` and the free-form `metadata` (which can carry PII, e.g. the
+  invited address or an email change) are stripped, so a downstream store such as Telescope
+  never persists raw PII and account deletion needs no cross-library purge. The `onEvent`
+  hook and the audit webhook still receive the **complete** event; only the diagnostics
+  republish is redacted.
+</Callout>
 
 ### Subscribing
 
@@ -83,28 +92,35 @@ the principal is written **into** the store after the fact.
 
 `@adonis-agora/context` publishes a symmetric **write slot** for exactly this — a
 `globalThis` slot keyed by `Symbol.for('@agora/context:set')` (exported as `CONTEXT_SET`).
-AuthKit's client middleware uses that slot to populate the `userRef` once it resolves an
-identity, so you don't have to wire it yourself. Conceptually it does:
+AuthKit's client middleware uses that slot once it resolves an identity, so you don't have
+to wire anything yourself. It writes three things:
+
+- **`userRef`** — `{ type: 'user', id: identity.userId }`
+- **`globalRoles`** — the identity's roles claim
+- **`tenantId`** — derived from the first non-empty organization claim on the raw token:
+  `active_organization_id`, `org_id`, `organization_id`, `tenant_id`, `tid`
 
 ```ts
-// After the authenticator resolves an Identity, AuthKit writes the ref into the
-// ambient context via the published write slot — a no-op if @adonis-agora/context
-// is not installed or no context is active.
-import { Context } from '@adonis-agora/context'
-
-Context.set('userRef', { type: 'user', id: identity.userId })
-// Context.set('tenantId', identity.raw.org_id) // if you map orgs → tenants
+// What the bridge effectively writes, through the published write slot — a no-op
+// if @adonis-agora/context is not installed or no context is active.
+Context.set({
+  userRef: { type: 'user', id: identity.userId },
+  globalRoles: identity.globalRoles,
+  tenantId: identity.raw.active_organization_id, // first claim present, if any
+})
 ```
 
 <Callout type="info">
   The write is **best-effort**: if no context is active (a route the context middleware
   didn't cover), the value is silently dropped — it never throws. Make sure the context
   server middleware runs before `authkit_middleware`. See
-  [Context → customization](/docs/context/context/customization) for the write-slot contract.
+  [Context → customization](/docs/context/customization) for the write-slot contract.
 </Callout>
 
-If you map AuthKit organizations to context tenants, the active `org_id` claim is the natural
-source for `tenantId` — set it in your own middleware after `auth`.
+So mapping AuthKit organizations onto context tenants needs no middleware of your own: as
+long as the active organization travels in one of those claims, `tenantId` is already set for
+logging, durable jobs and Authz. Write your own value only when the tenant is *not* the
+organization on the token.
 
 ## Authz — the identity / userRef seam
 
@@ -121,8 +137,8 @@ export default defineConfig({
 ```
 
 The chain is: **OIDC claims → `Identity` → `resolveUser` → your user → `resolveUserRef` →
-Bouncer policy**. AuthKit's `globalRoles` (IdP claims) and `resolveAppRoles` (app-local
-roles) feed the role checks; Authz layers DB-backed permissions on top. Because both sides
+Bouncer policy**. AuthKit contributes the IdP's `globalRoles` claim; Authz owns roles and
+permissions in the database and layers them on top. Because both sides
 agree on the `userRef`, a durable job dispatched under a request's context (carrying that
 same ref) can re-evaluate the same policies on a worker.
 
@@ -193,9 +209,9 @@ behalf it is acting — useful for the audit trail of the erasure itself.
 
 | Seam | Library | Mechanism | Required? |
 | --- | --- | --- | --- |
-| Auth events | [Diagnostics](/docs/diagnostics) | `agora:authkit:*` channels via `onDiagnostic` | No (no-op when unsubscribed) |
+| Auth events | [Diagnostics](/docs/diagnostics) | `agora:authkit:*` channels via `onDiagnostic`, redacted payload | No (no-op when unsubscribed) |
 | Observability | [Telescope](/docs/telescope) | generic watcher + opt-in Security extension | No (optional peer) |
-| Current principal | [Context](/docs/context) | `CONTEXT_SET` write slot → `userRef` | No (silent if absent) |
+| Current principal | [Context](/docs/context) | `CONTEXT_SET` write slot → `userRef`, `globalRoles`, `tenantId` | No (silent if absent) |
 | Authorization | [Authz](/docs/authz) | `resolveUser` → `resolveUserRef` → Bouncer | No (separate library) |
 | Outbound resilience | [Resilience](/docs/resilience) | `resilience` policy on the client | No (optional peer) |
 | Erasure fan-out | [Durable](/docs/durable) | workflow triggered by `account.deleted` | No (your orchestration) |

--- a/content/docs/authkit/back-channel-logout.mdx
+++ b/content/docs/authkit/back-channel-logout.mdx
@@ -1,6 +1,7 @@
 ---
 title: Back-Channel Logout
 description: OIDC Back-Channel Logout — server-to-server session termination.
+icon: LogOut
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/client.mdx
+++ b/content/docs/authkit/client.mdx
@@ -1,6 +1,7 @@
 ---
 title: Client
 description: Wire a relying party with @adonis-agora/authkit-client.
+icon: PlugZap
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/client.mdx
+++ b/content/docs/authkit/client.mdx
@@ -43,11 +43,6 @@ const authkitClientConfig = defineConfig({
     await user.load('roles')
     return user
   },
-
-  resolveAppRoles: async (identity: Identity) => {
-    const rows = await UserRole.query().where('userId', identity.userId)
-    return rows.map((r) => r.role)
-  },
 })
 
 export default authkitClientConfig
@@ -100,21 +95,22 @@ interface Identity {
 }
 ```
 
-Since **v0.3.0** all three resolvers (`jwt`, `pat`, `opaque`) populate `profile.avatarUrl`
-(from `picture`) and `sessionId` (from `sid`) — the `pat`/`opaque` paths now match `jwt`,
-so these fields are available regardless of token model.
+All three resolvers (`jwt`, `pat`, `opaque`) populate `profile.avatarUrl` (from `picture`)
+and `sessionId` (from `sid`), so those fields are available regardless of token model.
 
-## resolveUser & resolveAppRoles
+## resolveUser
 
 - **`resolveUser(identity, ctx)`** — map the identity to *your* user record (create on
-  first login, hydrate relations). Whatever you return becomes the authenticated user.
-- **`resolveAppRoles(identity)`** — app-local roles (distinct from the IdP's
-  `globalRoles`), e.g. for your authorization policies.
+  first login, hydrate relations). Whatever you return becomes the authenticated user, and
+  `ctx` carries the `accessToken` when one is available.
+- Roles are **not** resolved here: `globalRoles` come from the IdP claim (configurable via
+  `globalRolesClaim`), and anything finer-grained belongs to
+  [Authz](/docs/authz), which owns roles and permissions in the database.
 
 <Callout type="info">
   `resolveUser` is the seam Agora's [Authz](/docs/authz) hooks into via `resolveUserRef` —
   the same identity that becomes your app user also resolves the user reference Bouncer
-  checks against. See [Agora integration](/docs/authkit/agora-integration#authz-the-identityuserref-seam).
+  checks against. See [Agora integration](/docs/authkit/agora-integration#authz--the-identity--userref-seam).
 </Callout>
 
 ## Middleware

--- a/content/docs/authkit/compliance.mdx
+++ b/content/docs/authkit/compliance.mdx
@@ -1,6 +1,7 @@
 ---
 title: Compliance (LGPD / GDPR)
 description: Account deletion with cascade, data export, verified-email gate, verified email-change flow, and security notifications.
+icon: Scale
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/device-flow.mdx
+++ b/content/docs/authkit/device-flow.mdx
@@ -1,6 +1,7 @@
 ---
 title: Device Flow
 description: RFC 8628 — the OAuth 2.0 Device Authorization Grant for input-constrained devices.
+icon: Tv
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/getting-started.mdx
+++ b/content/docs/authkit/getting-started.mdx
@@ -441,15 +441,12 @@ const identity = await auth.getIdentity()
 if (identity) console.log(identity.userId, identity.sessionId, identity.raw)
 ```
 
-### Roles — `hasGlobalRole` / `hasAppRole`
+### Roles — `hasGlobalRole`
 
-Two role surfaces, mirroring Identity vs User:
-
-- **`hasGlobalRole(role)`** is synchronous and checks `identity.globalRoles` (IdP claims).
-  It only sees roles after the identity is resolved — call `authenticate()` / `check()` /
-  `getIdentity()` first.
-- **`hasAppRole(role)`** is `async`, consults `resolveAppRoles(identity)` (your app-local
-  roles), and resolves the identity for you.
+The authenticator exposes a single role check: **`hasGlobalRole(role)`**. It is synchronous
+and reads `identity.globalRoles` (the IdP claim, `roles` by default — configurable with
+`globalRolesClaim`), so it only sees roles once the identity is resolved. Call
+`authenticate()` / `check()` / `getIdentity()` first.
 
 ```ts
 async handle({ auth, response }: HttpContext) {
@@ -457,11 +454,11 @@ async handle({ auth, response }: HttpContext) {
   if (!auth.hasGlobalRole('admin')) {       // sync, from claims
     return response.forbidden({ message: 'Access denied' })
   }
-  if (await auth.hasAppRole('billing.manager')) {
-    // app-local capability
-  }
 }
 ```
+
+Anything finer-grained than an IdP claim — app-local roles, permissions, per-tenant grants —
+belongs to [Authz](/docs/authz), which owns them in the database and feeds Bouncer.
 
 ### Protecting a route group
 

--- a/content/docs/authkit/getting-started.mdx
+++ b/content/docs/authkit/getting-started.mdx
@@ -1,6 +1,7 @@
 ---
 title: Getting Started
 description: Stand up an Authorization Server, wire a relying party, and read the user in your controllers via ctx.auth.
+icon: Rocket
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/impersonation.mdx
+++ b/content/docs/authkit/impersonation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Impersonation
 description: Act as another user via RFC 8693 token-exchange.
+icon: VenetianMask
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/mfa.mdx
+++ b/content/docs/authkit/mfa.mdx
@@ -1,6 +1,7 @@
 ---
 title: MFA / TOTP
 description: Authenticator enrollment, the login challenge, recovery codes, and trusted devices.
+icon: Smartphone
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/observability.mdx
+++ b/content/docs/authkit/observability.mdx
@@ -1,6 +1,7 @@
 ---
 title: Observability
 description: Metrics, the OTel recorder, the JSON/dashboard routes, and the Telescope Security dashboard.
+icon: Gauge
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/organizations.mdx
+++ b/content/docs/authkit/organizations.mdx
@@ -1,6 +1,7 @@
 ---
 title: Organizations
 description: Multi-tenancy — organizations, members, invitations, and per-org token claims.
+icon: Building2
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/organizations.mdx
+++ b/content/docs/authkit/organizations.mdx
@@ -311,22 +311,32 @@ import {
   OrganizationProfile,
 } from '@adonis-agora/authkit-react'
 
-// Dropdown to switch the active organization; optionally shows a "Create org" button
-function Header({ activeOrgId }: { activeOrgId: string }) {
+// Dropdown listing the user's organizations, with the "personal account" entry
+// that deactivates the active org.
+function Header() {
   return (
     <>
       <OrganizationSwitcher
-        allowCreate={false}            // default; set true when organizations_policy.allowSelfCreate is on
-        createLabel="New organization"
+        personalAccountLabel="Personal account"
         className="my-custom-class"
       />
 
       {/* Full management card: members, invitations, leave/invite controls */}
-      <OrganizationProfile orgId={activeOrgId} className="my-custom-class" />
+      <OrganizationProfile
+        inviteLabel="Invite member"
+        leaveLabel="Leave organization"
+        className="my-custom-class"
+      />
     </>
   )
 }
 ```
+
+Neither component takes an organization id: both read the **active** organization from
+`useOrganizations()` / `useSwitchOrganization()`, so switching in the dropdown re-renders the
+profile card. `OrganizationSwitcher` renders nothing when the user is unauthenticated or the
+IdP does not expose organizations; `OrganizationProfile` renders nothing while no
+organization is active.
 
 Both components use the same `--authkit-*` CSS variables as the rest of the component kit;
 see [React](/docs/authkit/react) for the theming reference.

--- a/content/docs/authkit/passwordless.mdx
+++ b/content/docs/authkit/passwordless.mdx
@@ -1,6 +1,7 @@
 ---
 title: Passwordless
 description: Magic-link email login and passkey-first sign-in, without a password.
+icon: WandSparkles
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/personal-access-tokens.mdx
+++ b/content/docs/authkit/personal-access-tokens.mdx
@@ -1,6 +1,7 @@
 ---
 title: Personal Access Tokens
 description: Issue, list, and revoke PATs; validate them by introspection.
+icon: Ticket
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/react.mdx
+++ b/content/docs/authkit/react.mdx
@@ -1,6 +1,7 @@
 ---
 title: React (Frontend)
 description: useAuth, gating components, headless hooks, and pre-built UI for Inertia + React.
+icon: Atom
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/react.mdx
+++ b/content/docs/authkit/react.mdx
@@ -11,7 +11,7 @@ orthogonal layers:
 
 | Layer | What it does |
 | --- | --- |
-| **Auth state** | `useAuth()`, gating components (`Authenticated`, `Can`), role helpers |
+| **Auth state** | `useAuth()`, gating components (`Authenticated`, `Guest`, `CanPermission`), role helpers |
 | **Headless hooks** | `useProfile()`, `useSessions()`, `useOrganizations()`, … — plain `useState`/`useEffect`, no React Query |
 | **Pre-built components** | `SignInButton`, `UserButton`, `OrganizationSwitcher`, … — themeable via `--authkit-*` CSS variables |
 
@@ -53,7 +53,6 @@ export default defineConfig({
       return {
         user: user ?? null,
         globalRoles: auth.identity?.globalRoles ?? [],
-        // appRoles?: optional, if the host resolves app roles
       }
     },
   },
@@ -61,8 +60,9 @@ export default defineConfig({
 ```
 
 The `user` object must match `AuthUser`:
-`{ id, email, name?, avatarUrl?, globalRoles, appRoles? }` — the output of the client's
-`identityToUser` / `resolveUser`.
+`{ id, email, name?, avatarUrl?, globalRoles }` — the output of the client's
+`identityToUser` / `resolveUser`. `AuthUser` also carries an index signature, so the host is
+free to attach extra domain fields to the same object.
 
 ## 2. useAuth()
 
@@ -89,7 +89,7 @@ function Header() {
 ## 3. Gating components
 
 ```tsx
-import { Authenticated, Guest, Can } from '@adonis-agora/authkit-react'
+import { Authenticated, Guest, CanPermission } from '@adonis-agora/authkit-react'
 
 <Authenticated fallback={<LoginButton />}>
   <Dashboard />
@@ -99,20 +99,32 @@ import { Authenticated, Guest, Can } from '@adonis-agora/authkit-react'
   <MarketingBanner />
 </Guest>
 
-{/* single global role */}
-<Can role="ADMIN">
-  <AdminPanel />
-</Can>
-
-{/* require all roles */}
-<Can roles={['ADMIN', 'BILLING']} mode="all" fallback={<NoAccess />}>
-  <BillingSettings />
-</Can>
-
-{/* an app-specific role */}
-<Can role="EDITOR" appRole>
+{/* an Authz permission — checked over `POST /authz/can`, fail-closed */}
+<CanPermission permission="posts.update" fallback={<NoAccess />}>
   <EditButton />
-</Can>
+</CanPermission>
+
+{/* the same permission, scoped to a resource, with a placeholder while in flight */}
+<CanPermission
+  permission="posts.update"
+  resource="post:42"
+  loadingFallback={<Spinner />}
+  fallback={<NoAccess />}
+>
+  <EditButton />
+</CanPermission>
+```
+
+`CanPermission` is the only gating component that talks to the server; it wraps the `useCan()`
+hook (`{ allowed, loading, error }`), which caches per principal and is invalidated with
+`invalidateCanCache()`. There is **no role-gating component** — roles already travel in the
+token, so gate on them inline with `useAuth()`:
+
+```tsx
+const { hasGlobalRole, hasAnyGlobalRole } = useAuth()
+
+{hasGlobalRole('ADMIN') && <AdminPanel />}
+{hasAnyGlobalRole(['ADMIN', 'BILLING']) && <BillingSettings />}
 ```
 
 ## 4. AuthProvider (optional)
@@ -343,11 +355,12 @@ import {
   hasGlobalRole,
   hasAnyGlobalRole,
   hasAllGlobalRoles,
-  hasAppRole,
-  hasAnyAppRole,
-  hasAllAppRoles,
 } from '@adonis-agora/authkit-react'
 
 hasGlobalRole(user, 'ADMIN')
 hasAnyGlobalRole(user, ['ADMIN', 'TEACHER'])
+hasAllGlobalRoles(user, ['ADMIN', 'BILLING'])
 ```
+
+These three are the whole role surface: roles come from the IdP's global-roles claim. For
+anything finer-grained, use an Authz permission (`useCan()` / `CanPermission`).

--- a/content/docs/authkit/refresh-tokens.mdx
+++ b/content/docs/authkit/refresh-tokens.mdx
@@ -1,6 +1,7 @@
 ---
 title: Refresh Tokens
 description: Proactive refresh and rotation, handled by the client middleware.
+icon: RefreshCw
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/resolvers.mdx
+++ b/content/docs/authkit/resolvers.mdx
@@ -1,6 +1,7 @@
 ---
 title: Resolvers
 description: jwt, pat, and opaque — how a request becomes an Identity.
+icon: Waypoints
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/resolvers.mdx
+++ b/content/docs/authkit/resolvers.mdx
@@ -90,15 +90,14 @@ interface Identity {
 }
 ```
 
-Whatever resolver you pick, `resolveUser` and `resolveAppRoles` (see
-[Client](/docs/authkit/client)) are unchanged — the rest of your app never knows which token
-model produced the identity.
+Whatever resolver you pick, `resolveUser` (see [Client](/docs/authkit/client)) is
+unchanged — the rest of your app never knows which token model produced the identity.
 
-As of **v0.3.0** the `pat` and `opaque` resolvers populate `profile.avatarUrl` (from the
-introspection response's `picture`) and `sessionId` (from `sid`), matching what the `jwt`
-resolver already derives from the ID token. All three resolvers now yield the same fully
-populated `Identity` shape — `resolveUser` can rely on `identity.profile?.avatarUrl` and
-`identity.sessionId` regardless of token model.
+The `pat` and `opaque` resolvers populate `profile.avatarUrl` (from the introspection
+response's `picture`) and `sessionId` (from `sid`), matching what the `jwt` resolver derives
+from the ID token. All three yield the same fully populated `Identity` shape, so
+`resolveUser` can rely on `identity.profile?.avatarUrl` and `identity.sessionId` regardless
+of token model.
 
 ## Choosing a resolver
 

--- a/content/docs/authkit/sdk.mdx
+++ b/content/docs/authkit/sdk.mdx
@@ -1,6 +1,7 @@
 ---
 title: Backend SDK
 description: One typed interface, two drivers — remote (HTTP Admin API) and embedded (in-process).
+icon: SquareTerminal
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/topologies.mdx
+++ b/content/docs/authkit/topologies.mdx
@@ -1,6 +1,7 @@
 ---
 title: Deployment Topologies
 description: Run a dedicated IdP, or embed the provider inside an existing app.
+icon: Network
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/webauthn.mdx
+++ b/content/docs/authkit/webauthn.mdx
@@ -1,6 +1,7 @@
 ---
 title: WebAuthn / Passkeys
 description: Passkeys as a second factor — registration, the login challenge, and autofill.
+icon: Fingerprint
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';

--- a/content/docs/authkit/webauthn.mdx
+++ b/content/docs/authkit/webauthn.mdx
@@ -112,7 +112,7 @@ node ace authkit:settings:set auth_methods '{"passkeyAutofill":false}'
 
 **Custom login screens (React hosts):** use `usePasskeyAutofill` from
 `@adonis-agora/authkit-react` to replicate the same behaviour on a fully custom login
-page. See [React — usePasskeyAutofill](/docs/authkit/react#usepasskeyautofill).
+page. See [React — usePasskeyAutofill](/docs/authkit/react#8-usepasskeyautofill).
 
 **Browser support:** Chrome 108+, Safari 16+, Edge 108+. Browsers without support silently
 skip the ceremony — the standard login form is always the fallback.

--- a/lib/libs.ts
+++ b/lib/libs.ts
@@ -79,7 +79,7 @@ export const libs: AgoraLib[] = [
     role: 'Workflows',
     icon: Workflow,
     iconName: 'Workflow',
-    packages: 2,
+    packages: 3,
     stage: 'beta',
   },
   {
@@ -91,7 +91,7 @@ export const libs: AgoraLib[] = [
     role: 'Observability',
     icon: Telescope,
     iconName: 'Telescope',
-    packages: 1,
+    packages: 2,
     stage: 'beta',
   },
   {
@@ -103,7 +103,7 @@ export const libs: AgoraLib[] = [
     role: 'Authorization',
     icon: ShieldCheck,
     iconName: 'ShieldCheck',
-    packages: 1,
+    packages: 2,
     stage: 'alpha',
   },
   {
@@ -115,7 +115,7 @@ export const libs: AgoraLib[] = [
     role: 'Storage',
     icon: Image,
     iconName: 'Image',
-    packages: 1,
+    packages: 3,
     stage: 'alpha',
   },
   {
@@ -139,7 +139,7 @@ export const libs: AgoraLib[] = [
     role: 'AI',
     icon: Bot,
     iconName: 'Bot',
-    packages: 1,
+    packages: 2,
     stage: 'alpha',
   },
   {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "type": "module",
   "scripts": {
     "sync:docs": "node scripts/sync-docs.mjs",
+    "check:links": "node scripts/check-links.mjs",
     "sync:docs:local": "AGORA_DOCS_LOCAL=1 node scripts/sync-docs.mjs",
     "predev": "AGORA_DOCS_LOCAL=1 node scripts/sync-docs.mjs",
     "dev": "next dev",
-    "prebuild": "node scripts/sync-docs.mjs",
+    "prebuild": "node scripts/sync-docs.mjs && node scripts/check-links.mjs",
     "build": "next build",
     "start": "serve out",
     "lint": "biome check",

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Fails the build when a root-absolute /docs link does not resolve to a real page.
+//
+//   node scripts/check-links.mjs
+//
+// Runs after scripts/sync-docs.mjs (see the `prebuild` script). It walks
+// content/docs, derives the URL every page will be served at, and then checks
+// every `](/docs...)` / `href="/docs..."` link found in that content against it.
+// This is the guard against the link rewriting silently double-prefixing slugs.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS_DIR = join(ROOT, 'content', 'docs');
+
+if (!existsSync(DOCS_DIR)) {
+  console.error(`✖ ${relative(ROOT, DOCS_DIR)} not found — run the docs sync first`);
+  process.exit(1);
+}
+
+/** Recursively list files under a directory. */
+function walk(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = join(dir, e.name);
+    return e.isDirectory() ? walk(p) : [p];
+  });
+}
+
+const pages = walk(DOCS_DIR).filter((f) => f.endsWith('.mdx') || f.endsWith('.md'));
+
+/** The URL fumadocs will serve a content file at. */
+function pageUrl(file) {
+  const parts = relative(DOCS_DIR, file).split(sep);
+  const last = parts.pop().replace(/\.mdx?$/, '');
+  if (last !== 'index') parts.push(last);
+  return `/docs${parts.length ? `/${parts.join('/')}` : ''}`;
+}
+
+const known = new Set(pages.map(pageUrl));
+
+// `](/docs...)` or `href="/docs..."` — capture the target up to the closing delimiter.
+const LINK = /(?:\]\(|href=")(\/docs[^)"\s]*)/g;
+
+const broken = [];
+let checked = 0;
+
+for (const file of pages) {
+  const text = readFileSync(file, 'utf8');
+  for (const [, raw] of text.matchAll(LINK)) {
+    checked += 1;
+    // Drop the anchor / query, then the trailing slash.
+    const target = raw.split('#')[0].split('?')[0].replace(/\/$/, '');
+    if (!target || known.has(target)) continue;
+    broken.push({ file: relative(ROOT, file), target: raw });
+  }
+}
+
+if (broken.length > 0) {
+  console.error(`\n✖ ${broken.length} broken internal link${broken.length === 1 ? '' : 's'}:\n`);
+  for (const { file, target } of broken) console.error(`  ${file}  →  ${target}`);
+  console.error(
+    `\n  ${checked} /docs links checked against ${known.size} pages.` +
+      '\n  Links inside a library repo may be written either repo-local (/docs/guide) or' +
+      '\n  aggregator-absolute (/docs/<lib>/guide); both are accepted, missing pages are not.\n',
+  );
+  process.exit(1);
+}
+
+console.log(`✓ ${checked} internal /docs links resolve across ${known.size} pages`);

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -5,9 +5,10 @@
 //   node scripts/sync-docs.mjs filter     # sync one library (even if not migrated)
 //   AGORA_DOCS_LOCAL=1 node scripts/...    # copy from sibling repos instead of cloning
 //
-// For each library it: fetches the docs subtree, rewrites root-absolute /docs
-// links to be nested under /docs/<slug>, and turns the top-level meta.json into a
-// sidebar "root" tab carrying the library's name + icon.
+// For each library it: fetches the docs subtree, nests repo-local root-absolute
+// /docs links under /docs/<slug> (links that already name a library slug are left
+// alone), and turns the top-level meta.json into a sidebar "root" tab carrying the
+// library's name + icon. Run scripts/check-links.mjs afterwards to prove the result.
 
 import { execFileSync } from 'node:child_process';
 import {
@@ -75,11 +76,27 @@ function fetchRepo(src, tmp) {
   return tmp;
 }
 
-/** Rewrite root-absolute /docs links so they nest under the library slug. */
+// Every slug this site serves under /docs — the synced libraries plus the
+// hand-authored authkit copy. Used to tell an already-aggregator-absolute link
+// (`/docs/durable/stores/lucid`) apart from a repo-local one (`/docs/stores/lucid`).
+const KNOWN_SLUGS = new Set([...sources.map((s) => s.slug), 'authkit']);
+
+// `](/docs...` or `href="/docs...`, capturing the first path segment (if any).
+const DOCS_LINK = /(\]\(|href=")\/docs(\/[A-Za-z0-9._-]+)?/g;
+
+/**
+ * Rewrite root-absolute /docs links so they nest under the library slug.
+ *
+ * Idempotent and defensive: a link that already starts with a known library slug
+ * (`/docs/durable/...`, including cross-library links like `/docs/context/...`) is
+ * left alone; only repo-local links (`/docs/getting-started`) get the slug added.
+ */
 function rewriteLinks(content, slug) {
-  return content
-    .replaceAll('](/docs', `](/docs/${slug}`)
-    .replaceAll('href="/docs', `href="/docs/${slug}`);
+  return content.replace(DOCS_LINK, (match, open, first) => {
+    const segment = first?.slice(1);
+    if (segment && KNOWN_SLUGS.has(segment)) return match;
+    return `${open}/docs/${slug}${first ?? ''}`;
+  });
 }
 
 /** Point root-absolute asset refs at the vendored per-library public dir. */


### PR DESCRIPTION
Site-side fixes from the 2026-08-18 audit. Library docs themselves are being fixed in their own repos in parallel; nothing here touches synced content.

## A — 800+ internal links pointed at 404s

`scripts/sync-docs.mjs` prefixed *every* root-absolute `/docs` link with the library slug, but each repo already writes links in the aggregator's shape. The result was `/docs/durable/durable/stores/lucid` (no such route), and cross-library links were mangled into `/docs/telescope/context/...`.

The rewrite is now idempotent: a link whose first segment is a known library slug is left alone; a repo-local link (`/docs/getting-started`) still gets the slug. Slugs come from `docs-sources.mjs` plus `authkit`.

New `scripts/check-links.mjs` (`pnpm check:links`, wired into `prebuild`) fails the build when a generated link resolves to no page — measured **822 broken links before, 0 after**.

## B — wrong package counts

Verified against npm: telescope 2, authz 2, agent 2, media 3, durable 3 (durable was wrong too: it ships `durable-dashboard` as well). The home page's `totalPackages` goes from 20 to 26.

## C — AuthKit pages had no sidebar icons

The 19 hand-authored pages other than `index` were the only pages in the site without an `icon:`. Each now has a distinct lucide export name; all 20 verified rendering in `out/`.

## D — identifiers that do not exist in the published packages

Checked against `packages/authkit-react/index.ts` + `src/` and `authkit-client`:

- `<Can role/roles/mode/appRole>` → `CanPermission` (permission + resource); role gating is `useAuth().hasGlobalRole`
- `appRoles` removed from `AuthUser` / the Inertia shared prop
- `hasAppRole` / `hasAnyAppRole` / `hasAllAppRoles` removed — only the three global-role helpers exist
- `resolveAppRoles` removed — not a field of `ClientConfigInput`
- `<OrganizationSwitcher allowCreate createLabel>` → `personalAccountLabel` / `className`; `<OrganizationProfile orgId>` → `inviteLabel` / `leaveLabel` / `className`

## E — wrong claims in `agora-integration.mdx`

- the diagnostics republish is **redacted** (`{ type, accountId, actorId, clientId }`; email/ip/metadata stripped) — `onEvent`/webhook still get the full event
- the client's context bridge already derives `tenantId` from the first present org claim and writes `globalRoles`; readers no longer told to set it themselves
- fixed the duplicated `/docs/context/context/customization` path

## F — broken anchors and stale version prose

`#usepasskeyautofill` → `#8-usepasskeyautofill`, `#authz-the-identityuserref-seam` → the heading's real slug, and both "v0.3.0" strings removed.

## Gates

`pnpm build` (static export) exits 0: sync 9 libraries / 168 files, `✓ 968 internal /docs links resolve across 189 pages`, 576 static pages generated, 188 HTML pages in `out/`. All 179 distinct internal link targets resolve to a file in `out/`; no `out/docs/<slug>/<slug>/` directory remains.