### PR TITLE
fix(PaymentFlow): stack the actor row on phones instead of wrapping it

### DIFF
--- a/components/payment-flow.tsx
+++ b/components/payment-flow.tsx
@@ -218,6 +218,37 @@ export function PaymentFlow({
           .pf-step { grid-template-columns: 1.4rem minmax(0, 13.5rem) minmax(0, 1fr); align-items: baseline; }
           .pf-step-why { grid-column: 3; }
         }
+
+        /*
+         * Below this width the actor row STACKS instead of wrapping.
+         *
+         * Wrapping was the bug: at ~390px the first actor takes the whole line, and the wire
+         * and the second actor share the next one — so the arrowhead ends up pointing into
+         * empty space with the second actor sitting BESIDE the line rather than at the end of
+         * it. The one thing the diagram exists to show, who calls whom, is exactly what got
+         * lost. Stacked, the wire becomes a vertical connector and the arrow points at the
+         * actor that actually receives the call.
+         */
+        @media (max-width: 559px) {
+          .pf-row { flex-direction: column; align-items: stretch; gap: 4px; }
+          .pf-wire { flex: none; min-width: 0; flex-direction: row; align-items: center; justify-content: center; gap: 9px; padding: 1px 0; }
+          .pf-wire-label { text-align: right; }
+          .pf-wire-rail { flex-direction: column; height: 30px; }
+          .pf-line { width: 2px; height: auto; flex: 1 1 auto; }
+          /* The head SVG is drawn horizontally; a quarter turn clockwise sends 'right' down
+             and 'left' up, which is what the column order already implies. */
+          .pf-wire-rail svg { transform: rotate(90deg); }
+          .pf-line-flow { background-image: repeating-linear-gradient(180deg, currentColor 0 6px, transparent 6px 11px) !important; background-size: 2px 11px; animation-name: pf-flow-up; }
+          .pf-line-flow[data-dir='right'] { animation-name: pf-flow-down; }
+          /* Reclaim the vertical budget the stacking spends: the whole figure is over a
+             screen tall on a phone, and every band pays this padding. */
+          .pf-band { padding: 10px 12px 12px; }
+          .pf-drop { padding: 2px 0; gap: 4px; }
+          .pf-drop-line { height: 10px; }
+          .pf-steps { margin-top: 10px; gap: 7px; }
+        }
+        @keyframes pf-flow-down { to { background-position: 0 11px } }
+        @keyframes pf-flow-up { to { background-position: 0 -11px } }
         @media (prefers-reduced-motion: reduce) { .pf-line-flow { animation: none } }
       `}</style>
 


### PR DESCRIPTION
Reported from a phone: the happy-path diagram "ficou estranho no mobile".

## What was wrong

At ~390px the `.pf-row` flex line wrapped: the first actor took the whole width, and the wire and the second actor shared the next line. So in the webhook band the arrowhead pointed **left into empty space**, with `gateway paid` sitting beside the line instead of at the end of it — the one thing the diagram exists to show, who calls whom, was exactly what got lost.

## Fix

Below 560px the row stacks and the wire becomes a vertical connector. The head SVG takes a quarter turn, which sends `right` down and `left` up — matching the column order — so the arrow points at the actor that actually receives the call: down into the gateway for `charge()`, up into your app for the webhook.

Band padding, the drop connectors and the step list also tighten on phones, to pay back some of the height stacking costs.

## Verified

Built the static export and loaded it at 390×844 with the site CSS actually loading (serving `out/` at the root — under a `/agora` prefix the stylesheet 404s and the page renders unstyled, which is a misleading way to check a layout).

- Webhook arrow points from `gateway paid` **up** to `your app /payments/webhook`.
- `document.scrollWidth === 390` — no horizontal overflow.
- `pnpm build` passes; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)