### PR TITLE
fix(code-flow): stack the filter-pipeline scene

### DIFF
--- a/components/code-flow.tsx
+++ b/components/code-flow.tsx
@@ -1546,6 +1546,7 @@ const SQL_LINES: { text: string; indent?: boolean }[] = [
 ];
 
 const filterPipeline: Scene = {
+  stack: true,
   files: [
     {
       name: 'app/controllers/users_controller.ts',
@@ -1553,8 +1554,7 @@ const filterPipeline: Scene = {
   async index(ctx: HttpContext) {
     const query = User.query()
 
-    const { page, size } =
-      applyFilterFromRequest(query, userFilter, ctx)
+    const { page, size } = applyFilterFromRequest(query, userFilter, ctx)
 
     return query.paginate(page, size)
   }
@@ -1595,7 +1595,7 @@ const filterPipeline: Scene = {
     },
     {
       file: 0,
-      lines: [5, 6],
+      lines: [5, 5],
       split: { file: 1, lines: [5, 8], window: [4, 9], hint: 'userFilter' },
       title: 'server policy first',
       actor: 'tenant scope — never client-supplied',
@@ -1632,7 +1632,7 @@ const filterPipeline: Scene = {
     },
     {
       file: 0,
-      lines: [5, 6],
+      lines: [5, 5],
       title: 'page and size come back',
       actor: 'resolved, clamped — not executed',
       stage: 'paginate',
@@ -1641,7 +1641,7 @@ const filterPipeline: Scene = {
     },
     {
       file: 0,
-      lines: [8, 8],
+      lines: [7, 7],
       title: 'you execute it',
       actor: 'query.paginate(page, size)',
       stage: 'execute',


### PR DESCRIPTION
Side by side the controller line was clipped mid-argument and the SQL panel rendered at ~9px in a 358px column. Stacked (the layout the bigger durable scenes use) the code gets full width and the statement renders at 18px.

Verified locally with a full build + browser check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQcN9uhqfmk9Rzsc5RfXqM