### PR TITLE
ci: let pnpm/action-setup read packageManager instead of pinning pnpm 10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,9 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # No `version:` here — pnpm/action-setup reads the root `packageManager` field, so
+      # bumping pnpm in package.json cannot drift from (or conflict with) the workflow.
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Every deploy since #12 failed at the pnpm setup step with `Multiple versions of pnpm specified`: the workflow pinned pnpm 10 while `package.json` now declares `pnpm@11.24.0`. Dropping the pin makes the action follow `packageManager`, so the two cannot drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)