### PR TITLE
chore(payments): drop ProviderTabs — every gateway block is a ProviderSwitch now

### DIFF
--- a/components/mdx.tsx
+++ b/components/mdx.tsx
@@ -13,7 +13,6 @@ import {
   ProviderMatrix,
   ProviderSummary,
   ProviderSwitch,
-  ProviderTabs,
 } from '@/components/payments-provider';
 import { QueueSim, SingletonSim } from '@/components/queue-sim';
 import { ReplayDiagram } from '@/components/replay-diagram';
@@ -54,7 +53,6 @@ export function getMDXComponents(components?: MDXComponents) {
     // Payments-lib doc scene (bare tag in the payments overview, replacing the ASCII happy path).
     PaymentFlow,
     // Payments-lib provider-aware pieces: follow the gateway picked in the page header.
-    ProviderTabs,
     ProviderSwitch,
     ProviderCase,
     ProviderMatrix,

--- a/components/payments-provider.tsx
+++ b/components/payments-provider.tsx
@@ -7,7 +7,6 @@
 // followed across tabs via the `storage` event. The MDX-facing components are registered as bare
 // tags in components/mdx.tsx, so the library's docs use them without importing anything.
 
-import { Tabs, type TabsProps } from 'fumadocs-ui/components/tabs';
 import {
   Popover,
   PopoverContent,
@@ -36,7 +35,6 @@ import {
   type PaymentsProvider,
   PROVIDER_QUERY_PARAM,
   PROVIDER_STORAGE_KEY,
-  tabValue,
 } from '@/lib/payments-providers';
 
 /**
@@ -224,65 +222,6 @@ export function ProviderSelect() {
         )}
       </PopoverContent>
     </Popover>
-  );
-}
-
-type ProviderTabsProps = Omit<
-  TabsProps,
-  'items' | 'defaultIndex' | 'defaultValue'
-> & { items: string[] };
-
-/**
- * `<Tabs>` whose tabs are gateways: it follows the selected provider and, when the reader clicks a
- * tab, that becomes the selection everywhere. When the selected gateway has no tab here (Stripe on
- * the Pix page) the reader's last local pick stays open and a line underneath says so.
- */
-export function ProviderTabs({ items, children, ...rest }: ProviderTabsProps) {
-  const { providers, selected, select } = useScope();
-  const slugs = useMemo(
-    () => items.map((label) => matchProvider(label, providers)?.slug ?? null),
-    [items, providers],
-  );
-  const [local, setLocal] = useState(items[0]);
-
-  const selectedIndex = selected ? slugs.indexOf(selected.slug) : -1;
-  const active = selectedIndex >= 0 ? items[selectedIndex] : local;
-  const notCovered = selected !== null && selectedIndex < 0;
-
-  // Remember what is on screen, so switching to a gateway with no tab here keeps the tab the
-  // reader was looking at rather than snapping back to the first one.
-  useEffect(() => {
-    if (selectedIndex >= 0) setLocal(items[selectedIndex]);
-  }, [selectedIndex, items]);
-
-  // fumadocs' simple-mode `Tabs` spreads the remaining props onto the primitive *after* its own
-  // `value`/`onValueChange`, so passing ours makes it controlled (fumadocs-ui 16.15,
-  // dist/components/tabs.js). Its types omit the two; a JSX spread does not excess-check them.
-  const controlled = {
-    value: tabValue(active),
-    onValueChange: (value: string) => {
-      const index = items.findIndex((label) => tabValue(label) === value);
-      if (index < 0) return;
-      setLocal(items[index]);
-      const slug = slugs[index];
-      if (slug) select(slug);
-    },
-  };
-
-  return (
-    <div className="my-4">
-      <Tabs items={items} className="my-0" {...rest} {...controlled}>
-        {children}
-      </Tabs>
-      {notCovered && selected && (
-        <p className="mt-1.5 text-xs text-fd-muted-foreground">
-          {selected.title} is not covered in this section — showing {active}.{' '}
-          <Link href={selected.url} className="text-fd-primary hover:underline">
-            {selected.title} guide →
-          </Link>
-        </p>
-      )}
-    </div>
   );
 }
 

--- a/lib/payments-providers.ts
+++ b/lib/payments-providers.ts
@@ -1,5 +1,5 @@
 // Provider-aware docs for the payments library. The reader picks the gateway they use once (the
-// selector on every /docs/payments page) and the pages follow: `<ProviderTabs>` switch to it,
+// selector on every /docs/payments page) and the pages follow: `<ProviderSwitch>` shows its block,
 // `<ProviderMatrix>` highlights its row, `<ProviderSummary>` restates that row at the top of the
 // page. Nothing is hidden until a gateway is picked — the default is today's "show everything".
 //
@@ -50,12 +50,4 @@ export function matchProvider(
   return providers.find(
     (p) => key.startsWith(p.slug) || providerKey(p.title).startsWith(key),
   );
-}
-
-/**
- * How fumadocs' simple-mode `<Tabs items>` derives a tab's value from its label (only the first
- * whitespace is replaced — that is their implementation, mirrored so a controlled value matches).
- */
-export function tabValue(label: string): string {
-  return label.toLowerCase().replace(/\s/, '-');
 }


### PR DESCRIPTION
## What

Removes `<ProviderTabs>` (and `tabValue`): the payments pattern pages now use `<ProviderSwitch>` (DavideCarvalho/adonis-agora-payments#17, merged), so nothing renders the tab bar anymore.

`tsc`, `biome`, full `next build` (969 pages) pass with the payments docs at their merged state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)