### PR TITLE
docs: add Filter, Collaboration and Payments to the home page

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agora
-description: The AdonisJS ecosystem — context, diagnostics, resilience, durable, telescope, authz, media, agent and authkit.
+description: The AdonisJS ecosystem — context, diagnostics, resilience, durable, telescope, authz, collaboration, media, filter, payments, agent and authkit.
 ---
 
 # Agora
@@ -17,7 +17,10 @@ emit to one diagnostics bus, and surface in one observability console.
 - **[Durable](/docs/durable)** — durable, resumable, cross-process workflows.
 - **[Telescope](/docs/telescope)** — a Telescope-style observability console with an extensible dashboard.
 - **[Authz](/docs/authz)** — DB-backed roles & permissions that feed AdonisJS Bouncer, with wildcards, tenancy and ace commands.
+- **[Collaboration](/docs/collaboration)** — collaborative editing (CRDT) for AdonisJS, with Yjs/Automerge/edge engines, Redis presence, version control, anchored comments and React client hooks.
 - **[Media](/docs/media)** — owner collections, image conversions, and column attachments on top of `@adonisjs/drive`.
+- **[Filter](/docs/filter)** — a typed query-param filter language for Lucid, with defineFilter classes, offset & cursor pagination, relations via whereHas, full-text and vector-similarity search, and a typed client with codegen.
+- **[Payments](/docs/payments)** — multi-gateway payments and Cashier-style billing, with 18 gateways behind one driver contract, invoice emission and method-based routing.
 - **[Agent](/docs/agent)** — a governed, durable-ready AI agent: streaming chat, tool-calling, HITL approvals, quota/cost accounting and multi-agent delegation.
 - **[AuthKit](/docs/authkit)** — a full OIDC/OAuth2 Authorization Server (IdP) + OIDC client + React ergonomics: MFA, passwordless, device flow, DPoP and more.
 

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -12,6 +12,7 @@
     "filter",
     "agent",
     "authkit",
-    "collaboration"
+    "collaboration",
+    "payments"
   ]
 }


### PR DESCRIPTION
## Summary
- The home page's "The libraries" list (`content/docs/index.mdx`) only enumerated 9 of the 12 migrated libraries — Filter, Collaboration and Payments were fully synced and navigable, but missing from the overview page. Added all three, matching the style/length of the existing entries.
- Fixed the frontmatter `description` on the same file, which listed the same stale 9 libraries.
- Found `content/docs/meta.json` was missing `"payments"` from the top-level nav pages list entirely (Collaboration was present, Payments never made it in) — added it so the sidebar matches what's actually synced.

## Test plan
- [x] `AGORA_DOCS_LOCAL=1 node scripts/sync-docs.mjs` — synced all 12 libraries locally from sibling checkouts
- [x] `node scripts/check-links.mjs --strict` — 1941 internal /docs links resolve across 326 pages, 0 broken
- [x] `pnpm run lint` (biome check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)