### PR TITLE
docs: refresh the end-to-end example and add an ecosystem conventions page

### DIFF
--- a/content/docs/conventions.mdx
+++ b/content/docs/conventions.mdx
@@ -1,0 +1,167 @@
+---
+title: Conventions
+description: Cross-cutting conventions every @adonis-agora/* library follows — pagination shapes, the meta envelope, and what `limit` is reserved for.
+---
+
+# Conventions
+
+Each Agora library ships on its own, but a caller should only have to learn a
+cross-cutting idea once. This page collects the conventions that hold across the
+whole ecosystem, so they live in one place instead of only inside each library's
+own reference.
+
+## Pagination
+
+There are exactly two pagination mechanisms, and which one a listing uses is
+decided by what its backend can actually do — not by taste. Both are defined by
+[`@adonis-agora/filter`](/docs/filter), which is the only library that ships
+both.
+
+### Offset — `page` / `size`
+
+For SQL/Lucid-backed listings, where the store can seek to an arbitrary row.
+
+**Request** — `page` is a **1-based** page number defaulting to `1`, and `size`
+is the page size. On the wire that is `?page=2&size=25`. This mirrors filter's
+`FilterInput.page` / `FilterInput.size`, which it resolves into:
+
+```ts
+// @adonis-agora/filter
+interface ResolvedPagination {
+  page: number
+  size: number
+}
+```
+
+— exactly the pair Lucid's `query.paginate(page, size)` takes.
+
+**Response** — the `meta` / `data` envelope Lucid's own `.paginate()`
+serializes to, with the window co-located under `meta`:
+
+```json
+{
+  "meta": { "page": 2, "size": 25, "total": 137 },
+  "data": []
+}
+```
+
+`meta.page` and `meta.size` are always the resolved (clamped, defaulted) values
+actually applied, not the raw request. Beyond those two, each library adds what
+its store can answer cheaply: `total` in authkit, `count` in durable and
+payments, `count` + `hasMore` in telescope. Read the window off `meta`; never
+assume a field the library does not document.
+
+The 0-based SQL offset is an implementation detail — `(page - 1) * size`,
+derived inside the store — and never appears in a public type.
+
+### Cursor — `after` / `first`
+
+For backends whose "next page" handle is an opaque, protocol-native token rather
+than a row offset: S3's `ListObjectsV2` continuation token, Qdrant's scroll
+`next_page_offset`, or a keyset over `createdAt`/`id`. There is no way to
+compute an offset or seek to page 7, so cursor is the honest match.
+
+**Request** — `after` is the opaque cursor from a previous page's `nextCursor`
+(omit it for the first page) and `first` is the page size. This mirrors filter's
+`CursorParams`.
+
+**Response** — filter's `CursorPage<T>`, field for field:
+
+```ts
+// @adonis-agora/filter
+interface CursorPage<T> {
+  items: T[]
+  nextCursor: string | null
+  prevCursor: string | null
+  hasNext: boolean
+  hasPrev: boolean
+}
+```
+
+Cursor values are **opaque**. Hand a `nextCursor` back as `after`; never parse
+one, never build one.
+
+**Forward-only backends.** Filter's `CursorParams` also carries `before` /
+`last` for backward paging, because it builds keyset predicates over SQL it
+controls and can run the comparison in reverse. Neither media's nor agent's
+backends can, so both **omit** `before` / `last` from their own `CursorParams`
+— a parameter that type-checks and then silently does nothing is worse than one
+that does not exist — and pin `prevCursor: null` / `hasPrev: false` in every
+response. Those two fields stay present so the page *is* the ecosystem's
+`CursorPage` and not a near-miss of it: code written against one renders the
+other with no conditional, and a surface that later gains backward paging fills
+them in without a breaking change. They are constants, not a bug.
+
+**Pages carrying more than one kind of item** use the envelope without `items`.
+Media's object listing returns common prefixes *and* objects in the same page,
+so it types that response as `CursorPageInfo & { folders, files }`, where
+`CursorPageInfo` is `Omit<CursorPage<never>, 'items'>`.
+
+### `limit` is a cap, not a page
+
+`limit` is reserved for bounding a result set that has no page companion, and it
+deliberately keeps that name — respelling it `size` would claim a paging
+mechanism that is not there. Live examples:
+
+- Telescope's `?limit=` on `/api/stats` (top-N families and tags),
+  `/api/metrics/screens` and `/api/profiles`; the `topN` panel's `limit`;
+  `storage.memory({ limit })`, which is a ring-buffer capacity; and the MCP
+  `list_entries` tool's `limit` argument.
+- Filter's own group-by-count aggregation, which takes `groupByCount[limit]` /
+  `groupByCount[offset]` — `limit` bounds the rows (highest count first) and
+  `offset` pages that bound. Durable's `GET /durable/api/runs/values` *is* that
+  aggregation, so it kept `limit`/`offset` when its run listing moved to
+  `page`/`size`.
+- Durable's `durable:runs --limit` ace flag — a row cap with no page companion,
+  mapped to `size` internally.
+- Agent's `recentToolCalls(limit)` / `recentThreads(limit)`.
+
+The rule of thumb: if the parameter has a page companion it is `size`; if it is
+a bare ceiling on how many rows come back, it is `limit`.
+
+### Structural match, not a dependency
+
+No library imports these types from `@adonis-agora/filter`. Each declares its
+own `page`/`size` fields, or its own `CursorParams` / `CursorPage`, and states
+in the docblock that it mirrors filter's — the same optional-integration
+convention the rest of the ecosystem follows, where a library lights up its
+neighbours when present rather than depending on them. Two concrete reasons:
+filter's barrel re-exports Lucid-typed members, and most of these contracts are
+implemented by stores that have no Lucid (and no filter) dependency at all.
+
+The one exception is [`@adonis-agora/durable`](/docs/durable), which already
+depends on `@adonis-agora/filter` for its dashboard's filtering. That gives it
+somewhere to pin the two shapes together at **compile time**:
+`packages/adonis/test/dashboard/pagination-shape.spec.ts` assigns a
+`ResolvedPagination` straight into a `RunQuery`'s paging half and asserts
+key-and-type equality invariantly in both directions, so a rename or a retype on
+either side stops compiling instead of silently drifting.
+
+### Which library uses which
+
+| Library | Mechanism | Paginated surface |
+| --- | --- | --- |
+| [agent](/docs/agent) | Cursor | Governance run read-model (`listRuns`), Qdrant `scrollChunks` |
+| [authkit](/docs/authkit) | Offset | Accounts, audit log, admin console and Admin API listings |
+| [authz](/docs/authz) | — | No paginated surface |
+| [collaboration](/docs/collaboration) | Offset | `listVersions` / `listComments` (`ListPageOptions`); the routes read `?page=&size=` |
+| [context](/docs/context) | — | No paginated surface |
+| [diagnostics](/docs/diagnostics) | — | No paginated surface |
+| [durable](/docs/durable) | Offset | Run listings — `RunQuery.page`/`.size`, `GET /durable/api/runs` |
+| [filter](/docs/filter) | Both | Defines both; the source of truth |
+| [media](/docs/media) | Cursor | Console object listing (S3) and collections listing |
+| [payments](/docs/payments) | Offset | Billing listings (`BillingListQuery`) |
+| [resilience](/docs/resilience) | — | No paginated surface |
+| [sail](/docs/sail) | — | No paginated surface |
+| [telescope](/docs/telescope) | Offset | Entry and trace listings (`EntryQuery`, `TraceIdQuery`) |
+
+Two things the table flattens:
+
+- **Collaboration** takes `page`/`size` on the request but its `GET
+  /collaboration/versions` and `GET /collaboration/comments` routes answer with
+  a bare array rather than the `meta` / `data` envelope.
+- A library's **driver/SPI layer** may keep the vocabulary of the protocol
+  underneath it. Media's `MediaStore.list` and `ExtendedDisk.list` still speak
+  `cursor`/`limit`; the dashboard maps `after` → `cursor` and `first` → `limit`
+  at its HTTP boundary. The convention governs the interfaces a *caller* uses,
+  not the SPI a custom store implements.

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -29,3 +29,6 @@ emit to one diagnostics bus, and surface in one observability console.
 Everything is wired through small `Symbol.for('@agora/<lib>:<name>')` capability slots, so a library
 lights up its neighbours **when present** and no-ops when absent — no hard dependencies between repos.
 Install only what you need.
+
+Cross-cutting shapes are shared the same way — matched structurally, never imported. See
+**[Conventions](/docs/conventions)** for the ones that hold ecosystem-wide, starting with pagination.

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -1,6 +1,7 @@
 {
   "pages": [
     "index",
+    "conventions",
     "---Libraries---",
     "context",
     "diagnostics",

--- a/examples/end-to-end/README.md
+++ b/examples/end-to-end/README.md
@@ -58,7 +58,8 @@ Open <http://localhost:3333>, click **Log in**, sign up with any email —
 you land back on the home page authenticated. From there:
 
 - **/documents** — 403 until you grant yourself a role (below), then 200.
-- **/telescope** — 401/403 until you're `ADMIN`.
+- **/telescope** — 401 while logged out, 403 once logged in without
+  `ADMIN`, 200 after.
 
 Grant yourself a role (find your id first — the home page shows your email,
 or query `app_users`):
@@ -157,53 +158,47 @@ the two never drift.
   propagation mechanism — a real multi-tenant app would derive it from the
   user's organization/workspace instead.
 
-## Upstream issues found while building this
+## What this example fixed upstream
 
-Building this example surfaced a few genuine gaps in the ecosystem — not
-this app's own bugs, but things worth knowing if you hit the same wall.
-Each is documented at its exact point of impact in the code; this is just an
-index:
+Building this app surfaced five genuine gaps in the ecosystem. **All five are
+fixed and released**, in the versions pinned in `package.json` above — nothing
+below is a wall you will hit today. Kept as an index of what changed, and of
+why a few files look the way they do:
 
-1. **`@adonis-agora/authkit-client@0.18.2`'s `node ace configure` always
-   crashes.** Its published `config/authkit_client.stub` contains a literal
-   backtick inside a comment; the codemod's template engine wraps stub
-   content in a JS template literal to compile it, and the unescaped
-   backtick closes that literal early —
-   `SyntaxError: Unexpected identifier 'resolveRoles'`. Worked around by
-   hand-writing `config/authkit_client.ts` (see the comment at its top for
-   the exact repro command).
-2. **`authkit-server`'s built-in login/consent/signup screens crash on the
-   documented minimal config.** `branding` is typed optional and every doc
-   (getting-started, quickstart, reference) treats it as pure theming you
-   can skip — but the interaction controller reads `cfg.branding.clients`
-   unconditionally, and no default is ever applied when the key is absent.
-   Worked around with the smallest valid `BrandingConfig` in
-   `config/authkit.ts`.
-3. **The documented minimal `AuthUser` model produces broken accounts.**
-   Two gaps compound: the built-in signup screen always collects a "Name"
-   field the Lucid store passes straight into `AuthUser.create()` (needs a
-   `fullName` column the docs never show), and nothing generates the
-   primary key (no doc shows a `@beforeCreate` UUID hook), so every created
-   account's `id` comes back as SQLite's internal `lastInsertRowid` instead
-   of a real id — the account silently becomes unreachable by its real id
-   one request later. See `app/models/auth_user.ts`.
-4. **Mounting `registerAuthHost` behind global CSRF breaks the token
-   exchange.** `@adonisjs/shield`'s CSRF protection (on by default in the
-   `web` starter kit) intercepts the OIDC provider's own machine-to-machine
-   `POST /oidc/token`, so `exchangeCode()` gets shield's HTML denial instead
-   of a JSON token response. Fixed with a route-prefix exemption in
-   `config/shield.ts`.
-5. **Composing `authorizeByRoles` as a dashboard's `authorize` hook loses
-   the 401-vs-403 distinction.** Telescope's dashboard guard decides 401 vs
-   403 by whether the *request* presented an `Authorization` header /
-   `?token=` — a heuristic built for its own `credentials: {token, basic}`
-   gate. `authorizeByRoles` authenticates via the app's session cookie
-   instead, which that heuristic never inspects, so an authenticated-but-
-   wrong-role denial and a genuinely anonymous one both come back as 401.
-   Access is still correctly denied either way; only the status code is
-   imprecise in this specific composition. Noted in `smoke-test.sh` step 10.
+1. **`node ace configure @adonis-agora/authkit-client` always crashed** — the
+   published config stub had a literal backtick inside a comment and the stub
+   codemod compiles stub content by wrapping it in a JS template literal.
+   Fixed in
+   [`authkit-client@0.18.3`](https://www.npmjs.com/package/@adonis-agora/authkit-client);
+   `config/authkit_client.ts` here is now that codemod's real output, with
+   `resolveUser` filled in.
+2. **The built-in login/consent/signup screens crashed without a `branding`
+   key**, which every doc treats as optional theming. `defineConfig` now
+   resolves a default `BrandingConfig`
+   ([`authkit-server@0.66.0`](https://www.npmjs.com/package/@adonis-agora/authkit-server)).
+   `config/authkit.ts` still sets `branding`, but only as theming now — drop it
+   and the screens work.
+3. **The documented minimal `AuthUser` model produced broken accounts** — no
+   `fullName` column for the signup screen's "Name" field, no `@beforeCreate`
+   id hook, and no `static selfAssignPrimaryKey = true` (so Lucid overwrote the
+   generated UUID with the raw INSERT result). The scaffolded stub and the docs
+   now ship the complete model; `app/models/auth_user.ts` matches it.
+4. **`configure` never scaffolded the `auth_users` migration**, so a host that
+   followed getting-started verbatim hit `no such table: auth_users` on the
+   first signup. It does now, and
+   `database/migrations/*_create_auth_users_table.ts` here matches that stub.
+5. **Mounting `registerAuthHost` behind shield's default CSRF broke the OIDC
+   token exchange.** This one was never a code bug: the `authkitCsrfExceptions`
+   helper already existed, it just was not mentioned anywhere you would look.
+   The docs and the `authkit:doctor` hint now name it, and `config/shield.ts`
+   uses it.
 
-None of these are workarounds for *this app's* design choices — each is
-reproducible by following the relevant library's own getting-started doc
-verbatim, and each is called out at its exact location in the code so it's
-easy to find and easy to remove once fixed upstream.
+One rough edge this example *closed itself* rather than worked around:
+telescope's dashboard guard used to infer 401-vs-403 from the request's shape,
+which never sees the session cookie `authorizeByRoles` authenticates with. Since
+[`telescope@0.20.0`](https://www.npmjs.com/package/@adonis-agora/telescope) an
+`authorize` hook may return `{ allowed, reason }` instead of a bare boolean, and
+`config/telescope_ui.ts` does — so a wrong-role denial is a 403 and only an
+anonymous one is a 401 (asserted in `smoke-test.sh` step 10). `authz`'s
+`authorizeByRoles` still returns a plain boolean, so this composition is worth
+copying if you gate a dashboard the same way.

--- a/examples/end-to-end/app/models/auth_user.ts
+++ b/examples/end-to-end/app/models/auth_user.ts
@@ -4,51 +4,35 @@ import { withAuthUser, withCredentials } from '@adonis-agora/authkit-server'
 import { randomUUID } from 'node:crypto'
 
 /**
- * Por padrão o AuthKit cria/usa as tabelas na conexão DEFAULT da aplicação
- * (config/database.ts) — não força nenhum banco/schema próprio.
+ * The IdP-side account model. Same shape `node ace configure
+ * @adonis-agora/authkit-server` scaffolds (authkit-server@0.66.0+), with the
+ * comments translated — nothing here is app-specific.
  *
- * Se você quiser isolar o AuthKit num schema ou banco dedicado, defina uma
- * conexão no config/database.ts do app e referencie aqui, ex.:
- *
- *   static connection = 'auth'
- *
- * (e aponte as migrations correspondentes para essa conexão).
+ * By default AuthKit uses the app's DEFAULT database connection
+ * (config/database.ts); set `static connection = 'auth'` (and point the
+ * matching migrations at it) to isolate it on a dedicated one.
  */
 export default class AuthUser extends compose(BaseModel, withAuthUser(), withCredentials()) {
+  /**
+   * Required together with the `@beforeCreate` hook below: without it Lucid
+   * overwrites the assigned UUID with the raw INSERT result (the database's
+   * internal rowid) as soon as the row is saved.
+   */
+  static selfAssignPrimaryKey = true
+
   @column({ isPrimary: true })
   declare id: string
 
-  /**
-   * Also required, also undocumented: none of getting-started.mdx,
-   * starter.mdx, or account-store.mdx show a `@beforeCreate` hook (or any
-   * other id-generation) on `AuthUser`, yet the Lucid store's `.create()`
-   * (lucid_store/core.js) does a bare `Model.create({ email, password, ... })`
-   * with no `id` field — it fully expects the HOST model to self-assign a
-   * primary key. `id` is a plain string column (not an INTEGER autoincrement),
-   * so SQLite happily inserts it as NULL with no error. The first
-   * signup/login then serializes that as the STRING `"null"` into the OIDC
-   * session (`accountId: "null"`), and the very next account lookup —
-   * `WHERE id = 'null'` instead of `WHERE id IS NULL` — finds nothing,
-   * surfacing minutes later as the oidc-provider's generic
-   * "oops! something went wrong" page with no indication the real cause was
-   * a missing id. Reproduced by copying the documented model verbatim; see
-   * this repo's README.
-   */
+  /** Neither mixin generates the primary key — the host model owns it. */
   @beforeCreate()
   static assignUuid(user: AuthUser) {
     user.id = randomUUID()
   }
 
   /**
-   * Required even though authkit-server's own docs (getting-started.mdx,
-   * starter.mdx, account-store.mdx) show `AuthUser` with only `id` beyond the
-   * mixins. The bundled Edge signup screen collects a "Name" field
-   * unconditionally, and the Lucid store's `.create()` always passes
-   * `fullName: input.fullName ?? null` straight into `AuthUser.create(...)`
-   * (see `lucid_store/core.js`) — without this column Lucid throws `Cannot
-   * define "fullName" on "AuthUser" model, since it is not defined as a
-   * model property` on the very first signup. Reproduced by following the
-   * documented minimal model verbatim; see this repo's README.
+   * Not from a mixin: the built-in signup screen always collects a "Name"
+   * field and the Lucid account store passes it straight to
+   * `AuthUser.create()`.
    */
   @column()
   declare fullName: string | null

--- a/examples/end-to-end/config/authkit.ts
+++ b/examples/end-to-end/config/authkit.ts
@@ -23,19 +23,10 @@ const authServerConfig = defineConfig({
   // declared statically here, so no redeploy is needed to add one.
 
   /**
-   * WORKAROUND, not a design choice — `branding` is typed `optional` here and
-   * every doc (getting-started, quickstart, reference) treats it as pure
-   * theming you can skip. Omitting it entirely crashes the FIRST hit of the
-   * built-in login/consent/signup screen for every visitor:
-   * `brandFor(cfg.branding, ...)` in the host's interaction controller reads
-   * `cfg.branding.clients` unconditionally, and `defineConfig` never applies
-   * a default `{}` — `config.branding` stays `undefined` and the read
-   * throws `TypeError: Cannot read properties of undefined (reading
-   * 'clients')`. Reproduced on @adonis-agora/authkit-server@0.65.2 by simply
-   * following getting-started.mdx verbatim (no branding key) and opening
-   * /auth/login. This is the smallest valid BrandingConfig, purely to keep
-   * the built-in Edge login screen from crashing — see this repo's README
-   * for the full writeup; flagged upstream, not fixed here.
+   * Pure theming, and entirely optional: `defineConfig` resolves a neutral
+   * default `BrandingConfig` when the key is absent (authkit-server@0.66.0+),
+   * so the built-in login/consent/signup screens work without it. Set here
+   * only so those screens say "End-to-end example" instead of "AuthKit".
    */
   branding: {
     company: 'Agora',

--- a/examples/end-to-end/config/authkit_client.ts
+++ b/examples/end-to-end/config/authkit_client.ts
@@ -4,23 +4,8 @@ import type { Identity } from '@adonis-agora/authkit-client'
 import AppUser from '#models/app_user'
 
 /**
- * Hand-written rather than published by `node ace configure @adonis-agora/authkit-client`.
- *
- * That codemod currently crashes on this exact file: its published stub
- * (config/authkit_client.stub) contains a literal backtick inside a comment
- * (`` `resolveRoles` ``), and the codemod's template engine (tempura) compiles
- * a stub by wrapping its raw source in a JS template literal — an unescaped
- * backtick in the stub's own content closes that literal early and the
- * generated code fails with `SyntaxError: Unexpected identifier 'resolveRoles'`.
- * Reproduced directly against the installed package:
- *
- *   node -e "require('tempura').compile(require('fs').readFileSync(
- *     'node_modules/@adonis-agora/authkit-client/build/stubs/config/authkit_client.stub','utf8'))"
- *
- * This is a genuine upstream bug in @adonis-agora/authkit-client@0.18.2 (not a
- * misconfiguration on this app's part) — see this example's README for the
- * full writeup. Below is the config the codemod would have published, typed
- * by hand.
+ * Published verbatim by `node ace configure @adonis-agora/authkit-client`,
+ * with the stub's commented-out `resolveUser` placeholder filled in below.
  */
 const authkitClientConfig = defineConfig({
   issuer: env.get('AUTHKIT_ISSUER'),
@@ -39,6 +24,9 @@ const authkitClientConfig = defineConfig({
       { id: identity.userId, email: identity.email, fullName: identity.profile?.name ?? null },
     )
   },
+
+  // App roles? Configure `resolveRoles` in @adonis-agora/authz, not here —
+  // AuthKit only authenticates. See config/authz.ts.
 })
 
 export default authkitClientConfig

--- a/examples/end-to-end/config/shield.ts
+++ b/examples/end-to-end/config/shield.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@adonisjs/shield'
+import { authkitCsrfExceptions } from '@adonis-agora/authkit-server'
 
 /**
  * Security configuration using Shield.
@@ -42,24 +43,23 @@ const shieldConfig = defineConfig({
     enabled: true,
 
     /**
-     * Routes that should be excluded from CSRF protection.
-     * Useful for webhooks or API endpoints that use other auth methods.
+     * Routes excluded from CSRF protection.
      *
-     * `/oidc/*` is authkit-server's own OAuth2/OIDC protocol surface
-     * (`registerAuthHost`'s `mountPath`) — token, introspection, revocation,
-     * userinfo, etc. Those are machine-to-machine requests authenticated by
-     * the OIDC spec itself (client_secret_basic, PKCE), never by a browser
-     * form carrying our `_csrf` field. Left un-exempted, `exchangeCode()` in
+     * `authkitCsrfExceptions` is authkit-server's own helper for exactly this:
+     * it covers the IdP protocol surface mounted at `mountPath` (token,
+     * introspection, revocation, userinfo...), the PAT introspection route and
+     * the client's back-channel logout route. Those are machine-to-machine
+     * requests authenticated by the OIDC spec itself (client_secret_basic,
+     * PKCE), never by a browser form carrying shield's `_csrf` field — left
+     * un-exempted, `exchangeCode()` in
      * app/controllers/oidc_session_controller.ts gets shield's CSRF-denial
-     * HTML back from POST /oidc/token instead of a JSON token response, and
-     * fails with `SyntaxError: Unexpected token '<'... is not valid JSON` —
-     * reproduced with the web-starter-kit's default shield config (CSRF
-     * enabled) plus authkit-server's documented `registerAuthHost` setup.
-     * The actual interactive pages (login/signup/consent) live under
-     * `/auth/interaction/*`, a different prefix, so their CSRF protection is
-     * untouched by this exemption. See this repo's README.
+     * HTML back from `POST /oidc/token` instead of a JSON token response.
+     *
+     * The interactive pages (login/signup/consent) live under
+     * `/auth/interaction/*`, which the helper does not match, so their CSRF
+     * protection is untouched.
      */
-    exceptRoutes: (ctx) => ctx.request.url().startsWith('/oidc/'),
+    exceptRoutes: (ctx) => authkitCsrfExceptions(ctx.request.url(), { mountPath: '/oidc' }),
 
     /**
      * Enable XSRF-TOKEN cookie for JavaScript frameworks.

--- a/examples/end-to-end/config/telescope_ui.ts
+++ b/examples/end-to-end/config/telescope_ui.ts
@@ -1,14 +1,32 @@
 import { defineConfig } from '@adonis-agora/telescope/ui'
 import { authorizeByRoles } from '@adonis-agora/authz'
 
+const requireAdmin = authorizeByRoles({ roles: ['ADMIN'], loginPath: '/auth/login' })
+
 /**
- * The admin-only Telescope dashboard (goal #5). Mounts at /telescope,
- * gated with authz's shared dashboard helper — the same one used by
- * config/media_dashboard.ts and (per its own docs) every other
- * @adonis-agora dashboard (durable, agent). `loginPath` sends an
- * unauthenticated page navigation to this app's own login route instead of
- * the dashboard's own dead-end "you need to sign in" page.
+ * The admin-only Telescope dashboard (goal #5). Mounts at /telescope, gated
+ * with authz's shared dashboard helper — the same one used by
+ * config/media_dashboard.ts and (per its own docs) every other @adonis-agora
+ * dashboard (durable, agent). `loginPath` sends an unauthenticated page
+ * navigation to this app's own login route instead of the dashboard's own
+ * dead-end "you need to sign in" page.
+ *
+ * `authorizeByRoles` returns a bare boolean, and on a bare `false` telescope's
+ * guard picks 401 vs 403 from the REQUEST's shape (was an `Authorization`
+ * header or `?token=` presented?) — a heuristic built for its own
+ * `credentials: { token, basic }` gate, which never sees the session cookie
+ * this helper authenticates with. Returning telescope's `AuthorizeDecision`
+ * (`{ allowed, reason }`, telescope@0.20.0+) instead states the case outright,
+ * so an authenticated-but-wrong-role denial is a 403 and only a genuinely
+ * anonymous one is a 401.
  */
 export default defineConfig({
-  authorize: authorizeByRoles({ roles: ['ADMIN'], loginPath: '/auth/login' }),
+  authorize: async (ctx) => {
+    if (await requireAdmin(ctx)) return true
+
+    const auth = (ctx as { auth?: { getUser?: () => Promise<unknown>; user?: unknown } }).auth
+    const user = auth ? ((await auth.getUser?.()) ?? auth.user ?? null) : null
+
+    return { allowed: false, reason: user ? 'forbidden' : 'unauthenticated' }
+  },
 })

--- a/examples/end-to-end/database/migrations/1788795200000_create_auth_users_table.ts
+++ b/examples/end-to-end/database/migrations/1788795200000_create_auth_users_table.ts
@@ -1,40 +1,38 @@
 import { BaseSchema } from '@adonisjs/lucid/schema'
 
 /**
- * The table backing `AuthUser` (app/models/auth_user.ts), i.e. authkit-server's
- * `withAuthUser()` + `withCredentials()` mixins over `lucidAccountStore`.
- *
- * NOT published by `node ace configure @adonis-agora/authkit-server` — this is
- * hand-written glue. Worth flagging: neither authkit-server's getting-started
- * nor its quickstart doc mentions this migration at all, despite both walking
- * through exactly this `adapters.database` + `lucidAccountStore(AuthUser)`
- * setup; the first signup/login attempt without it fails with a raw
- * `SqliteError: no such table: auth_users` rather than a clear boot-time
- * check (contrast with authz, which either auto-creates its tables or ships
- * a migration + `createAuthzTables` helper for exactly this case). Columns
- * below are read straight off the two mixins' `@column()` declarations
- * (`with_auth_user.js` / `with_credentials.js`) since no schema helper exists
- * to generate them from.
+ * The table backing `AuthUser` (app/models/auth_user.ts) — i.e.
+ * authkit-server's `withAuthUser()` + `withCredentials()` mixins over
+ * `lucidAccountStore`. Same migration `node ace configure
+ * @adonis-agora/authkit-server` scaffolds (authkit-server@0.66.0+); it lives
+ * here, not inside the package, because AuthKit deliberately treats the
+ * account table as host-owned (`ensureAuthkitSchema()` never creates it).
  */
 export default class extends BaseSchema {
   protected tableName = 'auth_users'
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {
-      table.string('id').primary()
+      /**
+       * A string, NOT `increments()`: the model's `@beforeCreate` hook assigns
+       * a `randomUUID()` before the insert.
+       */
+      table.string('id').notNullable().primary()
+
+      // withAuthUser()
       table.string('email').notNullable().unique()
       table.string('password').notNullable()
-      // See app/models/auth_user.ts for why this column exists.
-      table.string('full_name').nullable()
-      table.text('global_roles').notNullable().defaultTo('[]')
-      table.timestamp('email_verified_at').nullable()
+      // Serialized as a JSON string ("[]" when empty) by the mixin.
+      table.json('global_roles').notNullable().defaultTo('[]')
+
+      // withCredentials()
+      table.timestamp('email_verified_at', { useTz: true }).nullable()
       table.string('email_verification_token').nullable()
       table.string('password_reset_token').nullable()
-      table.timestamp('password_reset_expires_at').nullable()
-      // No created_at/updated_at: app/models/auth_user.ts (mirroring the
-      // docs' own example) declares no such columns, and the mixins don't
-      // either — adding them here with no model column to populate them
-      // would just violate NOT NULL on the very first insert.
+      table.timestamp('password_reset_expires_at', { useTz: true }).nullable()
+
+      // The model's own column (see app/models/auth_user.ts).
+      table.string('full_name').nullable()
     })
   }
 

--- a/examples/end-to-end/database/schema.ts
+++ b/examples/end-to-end/database/schema.ts
@@ -151,7 +151,7 @@ export class AuthUserSchema extends BaseModel {
   @column()
   declare fullName: string | null
   @column()
-  declare globalRoles: string
+  declare globalRoles: any
   @column({ isPrimary: true })
   declare id: string
   @column({ serializeAs: null })

--- a/examples/end-to-end/package.json
+++ b/examples/end-to-end/package.json
@@ -56,13 +56,13 @@
     "youch": "^4.1.0-beta.13"
   },
   "dependencies": {
-    "@adonis-agora/authkit-client": "0.18.2",
-    "@adonis-agora/authkit-server": "0.65.2",
+    "@adonis-agora/authkit-client": "0.18.4",
+    "@adonis-agora/authkit-server": "0.66.0",
     "@adonis-agora/authz": "0.13.3",
     "@adonis-agora/context": "0.6.1",
-    "@adonis-agora/media": "0.15.1",
-    "@adonis-agora/telescope": "0.19.0",
-    "@adonis-agora/telescope-ui": "1.4.0",
+    "@adonis-agora/media": "0.18.0",
+    "@adonis-agora/telescope": "0.21.0",
+    "@adonis-agora/telescope-ui": "1.5.0",
     "@adonisjs/core": "^7.0.0-next.20",
     "@adonisjs/drive": "^4.0.0",
     "@adonisjs/lucid": "^22.0.0-next.4",

--- a/examples/end-to-end/pnpm-lock.yaml
+++ b/examples/end-to-end/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@adonis-agora/authkit-client':
-        specifier: 0.18.2
-        version: 0.18.2(@adonisjs/auth@10.1.0(9b3340e2852c810345912eec0a476284))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))(@adonisjs/session@8.1.0(f12882818712c60afe6fbbc569625e5d))
+        specifier: 0.18.4
+        version: 0.18.4(@adonisjs/auth@10.1.0(9b3340e2852c810345912eec0a476284))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))(@adonisjs/session@8.1.0(f12882818712c60afe6fbbc569625e5d))
       '@adonis-agora/authkit-server':
-        specifier: 0.65.2
-        version: 0.65.2(00202fb58f16b48b456254a727c8f73a)
+        specifier: 0.66.0
+        version: 0.66.0(8f5233e1b0b582333e175614c4d1ae70)
       '@adonis-agora/authz':
         specifier: 0.13.3
         version: 0.13.3(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))
@@ -21,14 +21,14 @@ importers:
         specifier: 0.6.1
         version: 0.6.1(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))
       '@adonis-agora/media':
-        specifier: 0.15.1
-        version: 0.15.1(4587c5d76c5a389629d9f63a310b6a2a)
+        specifier: 0.18.0
+        version: 0.18.0(0d440cf8a7398fff6161359e3f18efcf)
       '@adonis-agora/telescope':
-        specifier: 0.19.0
-        version: 0.19.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))
+        specifier: 0.21.0
+        version: 0.21.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))
       '@adonis-agora/telescope-ui':
-        specifier: 1.4.0
-        version: 1.4.0(@adonis-agora/telescope@0.19.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2)))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 1.5.0
+        version: 1.5.0(@adonis-agora/telescope@0.21.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2)))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@adonisjs/core':
         specifier: ^7.0.0-next.20
         version: 7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1)
@@ -129,12 +129,12 @@ importers:
 
 packages:
 
-  '@adonis-agora/authkit-client@0.18.2':
-    resolution: {integrity: sha512-+CmAvO+XEgIXfwV7oR9lq10NVhxOdp9HjWwP+yx93W1ygN/VIfQLlgkIKPzouLmKQWEayo1Fay6cGmNuFRTP6Q==}
+  '@adonis-agora/authkit-client@0.18.4':
+    resolution: {integrity: sha512-HEC90zEhcj1afQzSQtOdTYgTQkikRXM7CqLVQ4H/YM8FN/XYUHsjrKlqL2NnrUkS90+fsqS3ndpwoxxf6jCClQ==}
     peerDependencies:
       '@adonis-agora/resilience': '>=0.1.0 <1.0.0'
       '@adonisjs/auth': ^10.1.0
-      '@adonisjs/core': ^7.3.3
+      '@adonisjs/core': ^7.5.0
       '@adonisjs/lucid': ^22.4.2
       '@adonisjs/session': ^8.1.0
     peerDependenciesMeta:
@@ -148,8 +148,8 @@ packages:
   '@adonis-agora/authkit-core@0.8.0':
     resolution: {integrity: sha512-uGa/fpdlIRczVubcy6Y4KsYFl6dt5AQOxHBE2Qpd+G0GY8QMl/6XtyDpZgNMawLGIHZxf5GgjsdzlHri1BsUhg==}
 
-  '@adonis-agora/authkit-server@0.65.2':
-    resolution: {integrity: sha512-89CkTN3PdvjRpCRh8yvUT7EfRmz1wc/WGWs9yCUm8lrW03MvJ6S9H8GrV38t2/+/qYc3doDbhhMzaHFJOoQYvA==}
+  '@adonis-agora/authkit-server@0.66.0':
+    resolution: {integrity: sha512-/wFfbPnc6HnViFN/7WngDs5p/ICPhQrM+Ivq3BIfqXRE+mukf4iAh3yHLdChE5Od+vrWfRVy+zKnrXSa8DmDHA==}
     peerDependencies:
       '@adonis-agora/durable': '>=0.7.0 <1.0.0'
       '@adonis-agora/media': '>=0.5.0 <1.0.0'
@@ -207,8 +207,8 @@ packages:
     peerDependencies:
       '@adonisjs/core': ^7.3.0
 
-  '@adonis-agora/media@0.15.1':
-    resolution: {integrity: sha512-JyDYS4k1yq/FlFsW02vb+twOeJDrCb1jWSvNO/JoNXoOHP53FdIgiThX0URm26TOW7HXJmbPyj5chMqsBGpAXg==}
+  '@adonis-agora/media@0.18.0':
+    resolution: {integrity: sha512-NYlu1eLSItpe2dba0H//r4rp9MhStyXuJZPagf/RBsB4EYhB3sQL4AEdweMhi7TYBkXKlD3oFX9x2uOa0MhHuw==}
     engines: {node: '>=20.6.0'}
     peerDependencies:
       '@adonis-agora/telescope': '>=0.4.0 <1.0.0'
@@ -230,8 +230,8 @@ packages:
       sharp:
         optional: true
 
-  '@adonis-agora/telescope-ui@1.4.0':
-    resolution: {integrity: sha512-YSeWVGVrPUAuholkz+v3Wr8Uo2t2TsY0GFa4D2X9XZzHKSrdIj/OxYhg+QTwNoaD29MHCfFC2/jNd+4Cz32Zog==}
+  '@adonis-agora/telescope-ui@1.5.0':
+    resolution: {integrity: sha512-jdI0Mx1Wjo2whfsIumowJPIVfb2BVXdeH2TGgAIy090+qUyQId8OWisrrZM6el8/1/xifSCU0kheZqfvcu614A==}
     engines: {node: '>=20.6.0'}
     peerDependencies:
       '@adonis-agora/telescope': '>=0.11.0 <1.0.0'
@@ -240,8 +240,8 @@ packages:
       '@adonisjs/core':
         optional: true
 
-  '@adonis-agora/telescope@0.19.0':
-    resolution: {integrity: sha512-neR1+8o0zP5mEd3nsPBRuwyTIaHelkb6vImb/9MwoSc1MOkBWis3k2wrOWrCSnmI1QQv3Kqq4t9mSD8w3ODsFg==}
+  '@adonis-agora/telescope@0.21.0':
+    resolution: {integrity: sha512-2fx9gb7fxoI9mgk3YvN8aRiixZVMDUEytC0OczZVS4uHa+C07hkCn2ckNC4Qda/AWQ4tAr/lzY2MWIw3Hv63zg==}
     engines: {node: '>=20.6.0'}
     peerDependencies:
       '@adonisjs/cache': ^2.1.0
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.7.0':
-    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
+  '@base-ui/react@1.8.0':
+    resolution: {integrity: sha512-P0/1sxo6SBVZOklKMIedvTWqw2s2IQzi9x5bIVsXu980cuSOD4NeuRSs+/L7LZQfDkZP/uRZyGPyfFl/B1oH+Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -691,8 +691,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.3.2':
-    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
+  '@base-ui/utils@0.4.0':
+    resolution: {integrity: sha512-bO9fz25kKtPf+aZVyfQrC0PDmJdmVni31W2hCS5/Owb+inwdIL3XU26pCPRPlt4LSxZrBgLwubXQXQlKaFEZzw==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -1071,6 +1071,10 @@ packages:
     resolution: {integrity: sha512-SYHm4SoWSI0nRCoos6jpGusIqhPH9bbGBqv7ohlZ+H6BunrDzzQPk2ePgDuEUzV82OdvbLgtW4twUDwhU9P3YQ==}
     engines: {node: '>=14'}
 
+  '@peculiar/asn1-asym-key@2.9.4':
+    resolution: {integrity: sha512-s7SJfjcXlR3MYMngDTeMLCy3VjGaIxeEy905CQ0j09pDbeYhNBvBGA7r7cAvCZYkVFo9kVg9RAki0K2iUz7SGQ==}
+    engines: {node: '>=14'}
+
   '@peculiar/asn1-cms@2.9.4':
     resolution: {integrity: sha512-cben7oxmQsUGZqotus7yt0srYdncOT6RNWcTQ77T2RFOXejYVYkXadrfePdRcrVpO9K95IRLKKglG2k38jKXuw==}
     engines: {node: '>=14'}
@@ -1107,6 +1111,10 @@ packages:
     resolution: {integrity: sha512-ehQXbpQaQYycgu8OrvigwSPTFfVRcu0ECNYCWw+yzBp02Lw5paRqzzhUpfOgO2K38+WfFZuEz/0RPtam5g0OMg==}
     engines: {node: '>=14'}
 
+  '@peculiar/asn1-x509-post-quantum@2.9.4':
+    resolution: {integrity: sha512-GD0k7BY3dsEIeai7C7bVRPddj/PzZu+sTawRPRxdHKbdy1f9b58WQyk0eFJdr28GShyLVTU8poyi4+bTAZfEtQ==}
+    engines: {node: '>=14'}
+
   '@peculiar/asn1-x509@2.9.4':
     resolution: {integrity: sha512-CxhBo/RdEbMMob7T31ZdQjGuoyRFLVwrDzTn25bihzBasRg9kRm/0IxIPvhgQtcK/9dNcO1XQL2fuPugwELL0Q==}
     engines: {node: '>=14'}
@@ -1114,8 +1122,8 @@ packages:
   '@peculiar/utils@2.0.3':
     resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
 
-  '@peculiar/x509@1.14.3':
-    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+  '@peculiar/x509@2.1.0':
+    resolution: {integrity: sha512-IYbg1R03CSQGWwl24kGyqrdVtixNSbRaDvBg1r5wyYjTP+VwPQkka1BzTgU5+vxiuwqg04OxdvdJ1xYYFIdUSA==}
     engines: {node: '>=20.0.0'}
 
   '@phc/format@1.0.0':
@@ -1330,11 +1338,11 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@simplewebauthn/browser@13.3.0':
-    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
+  '@simplewebauthn/browser@14.0.0':
+    resolution: {integrity: sha512-1odWVqeEBTl7lJ9zMKLEsmTlnyrDO5iRcTvfMKKk1WThUnp/i8JJdffdj2icP+tty159s4PgwE3BiMoEW9NFow==}
 
-  '@simplewebauthn/server@13.3.3':
-    resolution: {integrity: sha512-LelX/lcy5cjc15A86i/aNxHhB5eU7dd20QsbP0VLAf9e38+SLlsnqCCyecx3xqfGofhmX05h1J9fKRYWxw+luA==}
+  '@simplewebauthn/server@14.0.1':
+    resolution: {integrity: sha512-kjWgcm9NdSv+Tobo4Swxd1WnEawsBogpYFMjg9pKsVLPN3FdCmR6BipkL+DcPDgmQ7UKbbBZqRqn3E3YaA7NBw==}
     engines: {node: '>=20.0.0'}
 
   '@sinclair/typebox@0.34.52':
@@ -2532,11 +2540,11 @@ packages:
     resolution: {integrity: sha512-e3cNNMpv8Kh20MjjphTXs+3Vz7DQyLM1nft7KJhnh46atFhjVJRa+0Hq0beywuwsACtMQUBihQkFl8zxb7gt1Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jose@5.10.0:
-    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
-
   jose@6.2.10:
     resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
+
+  jose@6.2.12:
+    resolution: {integrity: sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -2770,8 +2778,8 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  oidc-provider@9.12.0:
-    resolution: {integrity: sha512-/u5OCiXsWVedaADO9k3JIwK8oE5BAp9Kdbw105Tg+jIb3K89iwzN61Tmvq/ebCySW42geCJpWN92um58lnLKmw==}
+  oidc-provider@9.12.2:
+    resolution: {integrity: sha512-UaqeVpeijTocxVbDowPqPKloGjb49bxRSzHfChyI86teR+6xxoiI1V5jv8CHL2AIUmA2rg0xTZcYaC9GguympA==}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -3581,37 +3589,37 @@ packages:
 
 snapshots:
 
-  '@adonis-agora/authkit-client@0.18.2(@adonisjs/auth@10.1.0(9b3340e2852c810345912eec0a476284))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))(@adonisjs/session@8.1.0(f12882818712c60afe6fbbc569625e5d))':
+  '@adonis-agora/authkit-client@0.18.4(@adonisjs/auth@10.1.0(9b3340e2852c810345912eec0a476284))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))(@adonisjs/session@8.1.0(f12882818712c60afe6fbbc569625e5d))':
     dependencies:
       '@adonis-agora/authkit-core': 0.8.0
       '@adonisjs/core': 7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1)
       '@adonisjs/session': 8.1.0(f12882818712c60afe6fbbc569625e5d)
-      jose: 5.10.0
+      jose: 6.2.12
     optionalDependencies:
       '@adonisjs/auth': 10.1.0(9b3340e2852c810345912eec0a476284)
       '@adonisjs/lucid': 22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2)
 
   '@adonis-agora/authkit-core@0.8.0': {}
 
-  '@adonis-agora/authkit-server@0.65.2(00202fb58f16b48b456254a727c8f73a)':
+  '@adonis-agora/authkit-server@0.66.0(8f5233e1b0b582333e175614c4d1ae70)':
     dependencies:
       '@adonis-agora/authkit-core': 0.8.0
       '@adonisjs/core': 7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1)
       '@adonisjs/lucid': 22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2)
       '@adonisjs/session': 8.1.0(f12882818712c60afe6fbbc569625e5d)
       '@adonisjs/shield': 9.0.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/session@8.1.0(f12882818712c60afe6fbbc569625e5d))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)(supports-color@10.2.2))(@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)(supports-color@10.2.2))(@japa/browser-client@2.3.0(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)(playwright@1.63.0))(@japa/runner@5.3.0)(playwright@1.63.0))(edge.js@6.5.1)
-      '@simplewebauthn/browser': 13.3.0
-      '@simplewebauthn/server': 13.3.3
+      '@simplewebauthn/browser': 14.0.0
+      '@simplewebauthn/server': 14.0.1
       '@vinejs/vine': 4.4.0
-      jose: 6.2.10
+      jose: 6.2.12
       koa: 3.2.1
       koa-mount: 4.2.0(supports-color@10.2.2)
-      oidc-provider: 9.12.0(supports-color@10.2.2)
+      oidc-provider: 9.12.2(supports-color@10.2.2)
       otplib: 13.5.0
       qrcode: 1.5.4
     optionalDependencies:
-      '@adonis-agora/media': 0.15.1(4587c5d76c5a389629d9f63a310b6a2a)
-      '@adonis-agora/telescope': 0.19.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))
+      '@adonis-agora/media': 0.18.0(0d440cf8a7398fff6161359e3f18efcf)
+      '@adonis-agora/telescope': 0.21.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))
       '@adonisjs/auth': 10.1.0(9b3340e2852c810345912eec0a476284)
       '@adonisjs/drive': 4.0.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(edge.js@6.5.1)
       edge.js: 6.5.1
@@ -3628,18 +3636,18 @@ snapshots:
     dependencies:
       '@adonisjs/core': 7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1)
 
-  '@adonis-agora/media@0.15.1(4587c5d76c5a389629d9f63a310b6a2a)':
+  '@adonis-agora/media@0.18.0(0d440cf8a7398fff6161359e3f18efcf)':
     dependencies:
       '@adonisjs/core': 7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1)
       '@adonisjs/drive': 4.0.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(edge.js@6.5.1)
     optionalDependencies:
-      '@adonis-agora/telescope': 0.19.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))
+      '@adonis-agora/telescope': 0.21.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))
       '@adonisjs/lucid': 22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2)
 
-  '@adonis-agora/telescope-ui@1.4.0(@adonis-agora/telescope@0.19.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2)))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@adonis-agora/telescope-ui@1.5.0(@adonis-agora/telescope@0.21.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2)))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@adonis-agora/telescope': 0.19.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))
-      '@base-ui/react': 1.7.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@adonis-agora/telescope': 0.21.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))
+      '@base-ui/react': 1.8.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       tailwind-merge: 3.6.0
@@ -3652,7 +3660,7 @@ snapshots:
       - react
       - react-dom
 
-  '@adonis-agora/telescope@0.19.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))':
+  '@adonis-agora/telescope@0.21.0(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@adonisjs/core@7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@12.11.1)(luxon@3.7.2)(supports-color@10.2.2))':
     dependencies:
       '@adonisjs/core': 7.5.0(@adonisjs/assembler@8.5.1(typescript@5.9.3))(@vinejs/vine@4.4.0)(edge.js@6.5.1)(pino-pretty@13.1.3)(supports-color@10.2.2)(youch@4.1.1)
     optionalDependencies:
@@ -4037,17 +4045,17 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@base-ui/react@1.7.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@base-ui/react@1.8.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@base-ui/utils': 0.3.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@base-ui/utils': 0.4.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/utils': 0.2.12
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
-  '@base-ui/utils@0.3.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@base-ui/utils@0.4.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.12
@@ -4363,6 +4371,14 @@ snapshots:
       asn1js: 3.0.10
       tslib: 2.8.1
 
+  '@peculiar/asn1-asym-key@2.9.4':
+    dependencies:
+      '@peculiar/asn1-pkcs8': 2.9.4
+      '@peculiar/asn1-schema': 2.9.4
+      '@peculiar/asn1-x509': 2.9.4
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
   '@peculiar/asn1-cms@2.9.4':
     dependencies:
       '@peculiar/asn1-schema': 2.9.4
@@ -4432,6 +4448,14 @@ snapshots:
       asn1js: 3.0.10
       tslib: 2.8.1
 
+  '@peculiar/asn1-x509-post-quantum@2.9.4':
+    dependencies:
+      '@peculiar/asn1-asym-key': 2.9.4
+      '@peculiar/asn1-schema': 2.9.4
+      '@peculiar/asn1-x509': 2.9.4
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
   '@peculiar/asn1-x509@2.9.4':
     dependencies:
       '@peculiar/asn1-schema': 2.9.4
@@ -4443,7 +4467,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@peculiar/x509@1.14.3':
+  '@peculiar/x509@2.1.0':
     dependencies:
       '@peculiar/asn1-cms': 2.9.4
       '@peculiar/asn1-csr': 2.9.4
@@ -4452,8 +4476,8 @@ snapshots:
       '@peculiar/asn1-rsa': 2.9.4
       '@peculiar/asn1-schema': 2.9.4
       '@peculiar/asn1-x509': 2.9.4
+      '@peculiar/asn1-x509-post-quantum': 2.9.4
       pvtsutils: 1.3.6
-      reflect-metadata: 0.2.2
       tslib: 2.8.1
       tsyringe: 4.10.0
 
@@ -4619,9 +4643,9 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@simplewebauthn/browser@13.3.0': {}
+  '@simplewebauthn/browser@14.0.0': {}
 
-  '@simplewebauthn/server@13.3.3':
+  '@simplewebauthn/server@14.0.1':
     dependencies:
       '@hexagon/base64': 1.1.28
       '@levischuck/tiny-cbor': 0.2.11
@@ -4630,7 +4654,9 @@ snapshots:
       '@peculiar/asn1-rsa': 2.9.4
       '@peculiar/asn1-schema': 2.9.4
       '@peculiar/asn1-x509': 2.9.4
-      '@peculiar/x509': 1.14.3
+      '@peculiar/asn1-x509-post-quantum': 2.9.4
+      '@peculiar/x509': 2.1.0
+      reflect-metadata: 0.2.2
 
   '@sinclair/typebox@0.34.52': {}
 
@@ -5748,9 +5774,9 @@ snapshots:
       chalk: 4.1.2
       pretty-format: 30.5.1
 
-  jose@5.10.0: {}
-
   jose@6.2.10: {}
+
+  jose@6.2.12: {}
 
   joycon@3.1.1: {}
 
@@ -5956,7 +5982,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  oidc-provider@9.12.0(supports-color@10.2.2):
+  oidc-provider@9.12.2(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       jose: 6.2.10

--- a/examples/end-to-end/pnpm-workspace.yaml
+++ b/examples/end-to-end/pnpm-workspace.yaml
@@ -7,8 +7,9 @@ allowBuilds:
   esbuild: true
   '@swc/core': true
 minimumReleaseAgeExclude:
-  - '@adonis-agora/authkit-server@0.65.2'
+  - '@adonis-agora/authkit-client@0.18.4'
+  - '@adonis-agora/authkit-server@0.66.0'
   - '@adonis-agora/authz@0.13.3'
-  - '@adonis-agora/media@0.15.1'
-  - '@adonis-agora/telescope@0.19.0'
-  - '@adonis-agora/telescope-ui@1.4.0'
+  - '@adonis-agora/media@0.18.0'
+  - '@adonis-agora/telescope@0.21.0'
+  - '@adonis-agora/telescope-ui@1.5.0'

--- a/examples/end-to-end/smoke-test.sh
+++ b/examples/end-to-end/smoke-test.sh
@@ -8,8 +8,7 @@
 #   - authenticated but missing the "member" role -> 403
 #   - authenticated with "member" -> 200, can create + download own file
 #   - a second user, without the "manage" grant -> 403 on someone else's file
-#   - the Telescope dashboard -> denied anonymous AND non-admin (401 either
-#     way — see the note by step 10), 200 for ADMIN
+#   - the Telescope dashboard -> 401 anonymous, 403 non-admin, 200 for ADMIN
 #
 # Usage: BASE_URL=http://localhost:3333 ./smoke-test.sh
 set -euo pipefail
@@ -125,23 +124,15 @@ node ace authz:assign member "$(node -e "const D=require('better-sqlite3');const
 code="$(curl -s -o /dev/null -w '%{http_code}' -b "$WORKDIR/bob.jar" "$BASE_URL/documents/$doc_id/file")"
 expect_code "GET /documents/$doc_id/file (non-owner)" "403" "$code"
 
-echo "== 10. non-admin -> Telescope dashboard is still denied =="
-# NOTE: telescope's dashboard guard (ui/guard.js's runGuard) picks 401 vs 403
-# by whether the REQUEST presented a credential — an Authorization header or
-# a ?token= query param — not by what authorize() concluded. That heuristic
-# fits telescope's own built-in `credentials: {token, basic}` gate, but
-# authorizeByRoles authenticates via the app's session COOKIE, which this
-# heuristic never inspects — so with authorizeByRoles wired in (as here),
-# an authenticated-but-wrong-role denial and a genuinely anonymous one both
-# come back as 401, never the 403 the authz-side docs describe. Access is
-# correctly denied either way; only the status code is imprecise in this
-# specific composition. Accepting either code here rather than asserting one.
+echo "== 10. non-admin -> Telescope dashboard is 403, anonymous is 401 =="
+# config/telescope_ui.ts returns telescope's `AuthorizeDecision`
+# (`{ allowed, reason }`) rather than the bare boolean `authorizeByRoles`
+# gives, so the guard does not have to guess the status from the request's
+# shape — a session-cookie denial is told apart from an anonymous one.
 code="$(curl -s -o /dev/null -w '%{http_code}' -b "$WORKDIR/ada.jar" "$BASE_URL/telescope")"
-if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-  pass "GET /telescope (ada, member only) denied ($code)"
-else
-  fail "GET /telescope (ada, member only)" "401 or 403" "$code"
-fi
+expect_code "GET /telescope (ada, member only)" "403" "$code"
+code="$(curl -s -o /dev/null -w '%{http_code}' -H 'Accept: application/json' "$BASE_URL/telescope")"
+expect_code "GET /telescope (anonymous)" "401" "$code"
 
 echo "== 11. promote ada to ADMIN -> Telescope dashboard 200 =="
 node ace authz:assign ADMIN "$ada_id" > /dev/null 2>&1


### PR DESCRIPTION
## Why

Two unrelated docs gaps, both in this repo:

1. `examples/end-to-end` was pinned against library versions that have since been superseded, and its README opened newcomers with a list of **five upstream bugs that are all now fixed and released** — so the first thing a reader saw was a warning about walls that no longer exist, and the app carried workarounds it no longer needs.
2. All 13 libraries were unified on a single pagination interface, but that convention was documented only per-lib. There was no single page stating it.

## Version bumps

| package | was | now |
| --- | --- | --- |
| `@adonis-agora/authkit-client` | 0.18.2 | **0.18.4** |
| `@adonis-agora/authkit-server` | 0.65.2 | **0.66.0** |
| `@adonis-agora/media` | 0.15.1 | **0.18.0** |
| `@adonis-agora/telescope` | 0.19.0 | **0.21.0** |
| `@adonis-agora/telescope-ui` | 1.4.0 | **1.5.0** |
| `@adonis-agora/authz` | 0.13.3 | 0.13.3 (current) |
| `@adonis-agora/context` | 0.6.1 | 0.6.1 (current) |

## Workarounds removed / kept

- **`config/authkit_client.ts`** — the stub-backtick crash is fixed in `authkit-client@0.18.3+`. The file is now the real output of `node ace configure @adonis-agora/authkit-client`, with only `resolveUser` filled in.
- **`config/authkit.ts`** — `branding` **kept**, but as real theming. `defineConfig` resolves a default `BrandingConfig` since `authkit-server@0.66.0`, so omitting it no longer crashes the login/consent/signup screens; the comment says that instead of "WORKAROUND".
- **`app/models/auth_user.ts` + the `auth_users` migration** — both now match what `node ace configure @adonis-agora/authkit-server` scaffolds. That surfaced a **real bug in the example**: it was missing `static selfAssignPrimaryKey = true`, so Lucid overwrote the `@beforeCreate` UUID with the raw INSERT result. The long "here's the bug I hit" comments are gone.
- **`config/shield.ts`** — the CSRF exemption is **kept** (still required), but now uses the documented `authkitCsrfExceptions(url, { mountPath })` helper instead of a hand-written prefix check. It also covers PAT introspection and back-channel logout, which the hand-written check did not.
- **`config/telescope_ui.ts`** — the one README item that was *not* in the brief's list: the 401-vs-403 imprecision. `telescope@0.20.0+` lets an `authorize` hook return `{ allowed, reason }`, so the example now does that (`authz`'s `authorizeByRoles` still returns a bare boolean). A wrong-role denial is a 403 and only an anonymous one is a 401; `smoke-test.sh` step 10 asserts both instead of accepting either.

The README's *"Upstream issues found while building this"* is now **"What this example fixed upstream"** — an index of what changed and why a few files look the way they do, with links to the fixed versions.

## Conventions page

New `content/docs/conventions.mdx`, added to `content/docs/meta.json` and linked from the docs index. Covers offset (`page`/`size`, 1-based, `meta`/`data` envelope), cursor (`after`/`first` → filter's `CursorPage`, forward-only backends pinning `prevCursor: null` / `hasPrev: false`), `limit` being reserved for result caps, why libraries match structurally rather than importing `@adonis-agora/filter` (and durable's compile-time conformance test as the one exception), plus a per-library table.

Every claim was checked against the **published** packages rather than the sibling checkouts (several of which are on stale feature branches).

## Verification

Example: migrations from scratch, `node ace list:routes` (245 routes, no boot errors), `node ace test` (4 passed), `./smoke-test.sh` (all checks passed, driving the real OIDC + PKCE flow), `npx tsc --noEmit` clean.

Docs site: `AGORA_DOCS_LOCAL=1 node scripts/sync-docs.mjs`, `node scripts/check-links.mjs --strict` (1970 links across 329 pages), `pnpm lint`, and a full `pnpm build` from a clean `.next` — `/docs/conventions` renders.

> Note: the example's own `pnpm lint` fails with 35 pre-existing errors (36 on `main`); they are in generated files and pre-date this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)